### PR TITLE
Timing Method was uninitialized

### DIFF
--- a/UI/Components/DetailedTimerSettings.cs
+++ b/UI/Components/DetailedTimerSettings.cs
@@ -106,6 +106,7 @@ namespace LiveSplit.UI.Components
             Comparison = "Current Comparison";
             Comparison2 = "Best Segments";
             HideComparison = false;
+            TimingMethod = "Current Timing Method";
 
             chkShowGradientSegmentTimer.DataBindings.Add("Checked", this, "SegmentTimerShowGradient", false, DataSourceUpdateMode.OnPropertyChanged);
             chkShowGradientTimer.DataBindings.Add("Checked", this, "TimerShowGradient", false, DataSourceUpdateMode.OnPropertyChanged);


### PR DESCRIPTION
The TimingMethod variable wasn't initialized.
This could cause a crash (exception raised) if you add a DetailedTimer
in the Layout Manager.
This is done in the LiveSplit.Timer v1.5, see :
https://github.com/LiveSplit/LiveSplit.Timer/blob/1.5/UI/Components/TimerSettings.cs#L58
