### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.DetailedTimer.props
+++ b/props/LiveSplit.DetailedTimer.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.DetailedTimer.props
+++ b/props/LiveSplit.DetailedTimer.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.DetailedTimer/LiveSplit.DetailedTimer.csproj
+++ b/src/LiveSplit.DetailedTimer/LiveSplit.DetailedTimer.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="$(ComponentsPath)\LiveSplit.Timer\src\LiveSplit.Timer\LiveSplit.Timer.csproj" Private="false" ExcludeAssets="runtime" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -79,6 +79,7 @@ public class DetailedTimer : IComponent
             Settings.Comparison = args.NewName;
             ((LiveSplitState)sender).Layout.HasChanged = true;
         }
+
         if (Settings.Comparison2 == args.OldName)
         {
             Settings.Comparison2 = args.NewName;
@@ -101,6 +102,7 @@ public class DetailedTimer : IComponent
                 ImageAnimator.Animate(icon, (s, o) => { });
                 OldImage = icon;
             }
+
             var drawWidth = originalDrawSize;
             var drawHeight = originalDrawSize;
             if (icon.Width > icon.Height)
@@ -118,15 +120,17 @@ public class DetailedTimer : IComponent
 
             g.DrawImage(
                 icon,
-                7 + (originalDrawSize - drawWidth) / 2,
-                (height - originalDrawSize) / 2.0f + (originalDrawSize - drawHeight) / 2,
+                7 + ((originalDrawSize - drawWidth) / 2),
+                ((height - originalDrawSize) / 2.0f) + ((originalDrawSize - drawHeight) / 2),
                 drawWidth,
                 drawHeight);
 
             IconWidth = (int)(originalDrawSize + 7.5f);
         }
         else
+        {
             IconWidth = 0;
+        }
 
         InternalComponent.Settings.ShowGradient = Settings.TimerShowGradient;
         InternalComponent.Settings.OverrideSplitColors = Settings.OverrideTimerColors;
@@ -157,11 +161,13 @@ public class DetailedTimer : IComponent
             LabelSegment.ShadowColor = state.LayoutSettings.ShadowsColor;
             LabelSegment.OutlineColor = state.LayoutSettings.TextOutlineColor;
             if (Comparison != "None")
+            {
                 LabelSegment.Draw(g);
+            }
 
             LabelBest.Font = labelsFont;
             LabelBest.X = 5 + IconWidth;
-            LabelBest.Y = height * ((100f - Settings.SegmentTimerSizeRatio / 2f) / 100f);
+            LabelBest.Y = height * ((100f - (Settings.SegmentTimerSizeRatio / 2f)) / 100f);
             LabelBest.Width = width - SegmentTimer.ActualWidth - 5 - IconWidth;
             LabelBest.Height = height * (Settings.SegmentTimerSizeRatio / 200f);
             LabelBest.HorizontalAlignment = StringAlignment.Near;
@@ -171,7 +177,9 @@ public class DetailedTimer : IComponent
             LabelBest.ShadowColor = state.LayoutSettings.ShadowsColor;
             LabelBest.OutlineColor = state.LayoutSettings.TextOutlineColor;
             if (!HideComparison)
+            {
                 LabelBest.Draw(g);
+            }
 
             var offset = Math.Max(LabelSegment.ActualWidth, HideComparison ? 0 : LabelBest.ActualWidth) + 10;
 
@@ -196,7 +204,7 @@ public class DetailedTimer : IComponent
             {
                 BestSegmentTime.Font = timesFont;
                 BestSegmentTime.X = offset + IconWidth;
-                BestSegmentTime.Y = height * ((100f - Settings.SegmentTimerSizeRatio / 2f) / 100f);
+                BestSegmentTime.Y = height * ((100f - (Settings.SegmentTimerSizeRatio / 2f)) / 100f);
                 BestSegmentTime.Width = width - SegmentTimer.ActualWidth - offset - IconWidth;
                 BestSegmentTime.Height = height * (Settings.SegmentTimerSizeRatio / 200f);
                 BestSegmentTime.HorizontalAlignment = StringAlignment.Near;
@@ -208,6 +216,7 @@ public class DetailedTimer : IComponent
                 BestSegmentTime.IsMonospaced = true;
                 BestSegmentTime.Draw(g);
             }
+
             SplitName.Font = Settings.SplitNameFont;
             SplitName.X = IconWidth + 5;
             SplitName.Y = 0;
@@ -220,7 +229,9 @@ public class DetailedTimer : IComponent
             SplitName.ShadowColor = state.LayoutSettings.ShadowsColor;
             SplitName.OutlineColor = state.LayoutSettings.TextOutlineColor;
             if (Settings.ShowSplitName)
+            {
                 SplitName.Draw(g);
+            }
         }
     }
 
@@ -274,9 +285,13 @@ public class DetailedTimer : IComponent
         var Formatter = Settings.SegmentTimesFormatter;
         var timingMethod = state.CurrentTimingMethod;
         if (Settings.TimingMethod == "Real Time")
+        {
             timingMethod = TimingMethod.RealTime;
+        }
         else if (Settings.TimingMethod == "Game Time")
+        {
             timingMethod = TimingMethod.GameTime;
+        }
 
         if (state.CurrentSplitIndex >= 0)
         {
@@ -288,7 +303,9 @@ public class DetailedTimer : IComponent
             {
                 HideComparison = true;
                 if (!state.Run.Comparisons.Contains(Comparison) || Comparison == "None")
+                {
                     Comparison = state.CurrentComparison;
+                }
             }
             else if (!state.Run.Comparisons.Contains(Comparison) || Comparison == "None")
             {
@@ -296,7 +313,9 @@ public class DetailedTimer : IComponent
                 Comparison = Comparison2;
             }
             else if (Comparison == Comparison2)
+            {
                 HideComparison = true;
+            }
 
             ComparisonName = CompositeComparisons.GetShortComparisonName(Comparison);
             ComparisonName2 = CompositeComparisons.GetShortComparisonName(Comparison2);
@@ -304,14 +323,20 @@ public class DetailedTimer : IComponent
             TimeSpan? segmentTime = null;
 
             if (Comparison == BestSegmentsComparisonGenerator.ComparisonName)
+            {
                 segmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].BestSegmentTime[timingMethod];
+            }
             else
             {
                 if (state.CurrentSplitIndex == 0 || (state.CurrentSplitIndex == 1 && lastSplitOffset == -1))
+                {
                     segmentTime = state.Run[0].Comparisons[Comparison][timingMethod];
+                }
                 else if (state.CurrentSplitIndex > 0)
+                {
                     segmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].Comparisons[Comparison][timingMethod]
                         - state.Run[state.CurrentSplitIndex - 1 + lastSplitOffset].Comparisons[Comparison][timingMethod];
+                }
             }
 
             LabelSegment.Text = ComparisonName + ":";
@@ -327,18 +352,25 @@ public class DetailedTimer : IComponent
             {
                 TimeSpan? bestSegmentTime = null;
                 if (Comparison2 == BestSegmentsComparisonGenerator.ComparisonName)
+                {
                     bestSegmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].BestSegmentTime[timingMethod];
+                }
                 else
                 {
                     if (state.CurrentSplitIndex == 0 || (state.CurrentSplitIndex == 1 && lastSplitOffset == -1))
+                    {
                         bestSegmentTime = state.Run[0].Comparisons[Comparison2][timingMethod];
+                    }
                     else if (state.CurrentSplitIndex > 0)
+                    {
                         bestSegmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].Comparisons[Comparison2][timingMethod]
                             - state.Run[state.CurrentSplitIndex - 1 + lastSplitOffset].Comparisons[Comparison2][timingMethod];
+                    }
                 }
 
                 BestSegmentTime.Text = Formatter.Format(bestSegmentTime);
             }
+
             if (state.CurrentSplitIndex >= 0)
             {
                 string name = state.Run[state.CurrentSplitIndex + lastSplitOffset].Name;
@@ -346,18 +378,26 @@ public class DetailedTimer : IComponent
                 bool isSubsplit = name.StartsWith("-") && state.CurrentSplitIndex + lastSplitOffset < state.Run.Count - 1;
 
                 if (isSubsplit)
+                {
                     SplitName.Text = name.Substring(1);
+                }
                 else
                 {
                     Match match = SubsplitRegex.Match(name);
                     if (match.Success)
+                    {
                         SplitName.Text = match.Groups[2].Value;
+                    }
                     else
+                    {
                         SplitName.Text = name;
+                    }
                 }
             }
             else
+            {
                 SplitName.Text = "";
+            }
         }
 
         SegmentTimer.Settings.TimingMethod = Settings.TimingMethod;
@@ -372,10 +412,15 @@ public class DetailedTimer : IComponent
         if (Cache.HasChanged)
         {
             if (icon == null)
+            {
                 FrameCount = 0;
+            }
             else
+            {
                 FrameCount = icon.GetFrameCount(new FrameDimension(icon.FrameDimensionsList[0]));
+            }
         }
+
         Cache["SplitName"] = SplitName.Text;
         Cache["LabelSegment"] = LabelSegment.Text;
         Cache["LabelBest"] = LabelBest.Text;
@@ -386,9 +431,13 @@ public class DetailedTimer : IComponent
         if (InternalComponent.BigTextLabel.Brush != null && invalidator != null)
         {
             if (InternalComponent.BigTextLabel.Brush is LinearGradientBrush)
+            {
                 Cache["TimerColor"] = ((LinearGradientBrush)InternalComponent.BigTextLabel.Brush).LinearColors.First().ToArgb();
+            }
             else
+            {
                 Cache["TimerColor"] = InternalComponent.BigTextLabel.ForeColor.ToArgb();
+            }
         }
 
         if (invalidator != null && (Cache.HasChanged || FrameCount > 1))

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -379,7 +379,7 @@ public class DetailedTimer : IComponent
 
                 if (isSubsplit)
                 {
-                    SplitName.Text = name.Substring(1);
+                    SplitName.Text = name[1..];
                 }
                 else
                 {

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -51,7 +51,7 @@ public class DetailedTimer : IComponent
 
     public IDictionary<string, Action> ContextMenuControls => null;
 
-    private readonly Regex SubsplitRegex = new Regex(@"^{(.+)}\s*(.+)$", RegexOptions.Compiled);
+    private readonly Regex SubsplitRegex = new(@"^{(.+)}\s*(.+)$", RegexOptions.Compiled);
 
     public DetailedTimer(LiveSplitState state)
     {
@@ -91,10 +91,10 @@ public class DetailedTimer : IComponent
     {
         Timer.DrawBackground(g, InternalComponent.TimerColor, Settings.BackgroundColor, Settings.BackgroundColor2, width, height, Settings.BackgroundGradient);
 
-        var lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
+        int lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
 
-        var originalDrawSize = Math.Min(Settings.IconSize, width - 14);
-        var icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
+        float originalDrawSize = Math.Min(Settings.IconSize, width - 14);
+        Image icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
         if (Settings.DisplayIcon && icon != null)
         {
             if (OldImage != icon)
@@ -103,16 +103,16 @@ public class DetailedTimer : IComponent
                 OldImage = icon;
             }
 
-            var drawWidth = originalDrawSize;
-            var drawHeight = originalDrawSize;
+            float drawWidth = originalDrawSize;
+            float drawHeight = originalDrawSize;
             if (icon.Width > icon.Height)
             {
-                var ratio = icon.Height / (float)icon.Width;
+                float ratio = icon.Height / (float)icon.Width;
                 drawHeight *= ratio;
             }
             else
             {
-                var ratio = icon.Width / (float)icon.Height;
+                float ratio = icon.Width / (float)icon.Height;
                 drawWidth *= ratio;
             }
 
@@ -181,7 +181,7 @@ public class DetailedTimer : IComponent
                 LabelBest.Draw(g);
             }
 
-            var offset = Math.Max(LabelSegment.ActualWidth, HideComparison ? 0 : LabelBest.ActualWidth) + 10;
+            float offset = Math.Max(LabelSegment.ActualWidth, HideComparison ? 0 : LabelBest.ActualWidth) + 10;
 
             if (Comparison != "None")
             {
@@ -238,7 +238,7 @@ public class DetailedTimer : IComponent
     public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
     {
         DrawGeneral(g, state, width, VerticalHeight);
-        var oldMatrix = g.Transform;
+        Matrix oldMatrix = g.Transform;
         InternalComponent.Settings.TimerHeight = VerticalHeight * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
         InternalComponent.DrawVertical(g, state, width, clipRegion);
         g.Transform = oldMatrix;
@@ -251,7 +251,7 @@ public class DetailedTimer : IComponent
     public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
     {
         DrawGeneral(g, state, HorizontalWidth, height);
-        var oldMatrix = g.Transform;
+        Matrix oldMatrix = g.Transform;
         InternalComponent.Settings.TimerWidth = HorizontalWidth;
         InternalComponent.DrawHorizontal(g, state, height * ((100f - Settings.SegmentTimerSizeRatio) / 100f), clipRegion);
         g.Transform = oldMatrix;
@@ -281,9 +281,9 @@ public class DetailedTimer : IComponent
 
     public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
     {
-        var lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
-        var Formatter = Settings.SegmentTimesFormatter;
-        var timingMethod = state.CurrentTimingMethod;
+        int lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
+        TimeFormatters.GeneralTimeFormatter Formatter = Settings.SegmentTimesFormatter;
+        TimingMethod timingMethod = state.CurrentTimingMethod;
         if (Settings.TimingMethod == "Real Time")
         {
             timingMethod = TimingMethod.RealTime;
@@ -405,7 +405,7 @@ public class DetailedTimer : IComponent
         SegmentTimer.Update(null, state, width, height, mode);
         InternalComponent.Update(null, state, width, height, mode);
 
-        var icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
+        Image icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
 
         Cache.Restart();
         Cache["SplitIcon"] = icon;

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -51,7 +51,7 @@ public class DetailedTimer : IComponent
 
     public IDictionary<string, Action> ContextMenuControls => null;
 
-    private Regex SubsplitRegex = new Regex(@"^{(.+)}\s*(.+)$", RegexOptions.Compiled);
+    private readonly Regex SubsplitRegex = new Regex(@"^{(.+)}\s*(.+)$", RegexOptions.Compiled);
 
     public DetailedTimer(LiveSplitState state)
     {
@@ -71,7 +71,7 @@ public class DetailedTimer : IComponent
         state.ComparisonRenamed += state_ComparisonRenamed;
     }
 
-    void state_ComparisonRenamed(object sender, EventArgs e)
+    private void state_ComparisonRenamed(object sender, EventArgs e)
     {
         var args = (RenameEventArgs)e;
         if (Settings.Comparison == args.OldName)

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -401,5 +401,8 @@ public class DetailedTimer : IComponent
     {
     }
 
-    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
+    }
 }

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -1,406 +1,405 @@
-﻿using LiveSplit.Model;
-using LiveSplit.Model.Comparisons;
-using LiveSplit.TimeFormatters;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using System.Xml;
-using System.Text.RegularExpressions;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+
+namespace LiveSplit.UI.Components;
+
+public class DetailedTimer : IComponent
 {
-    public class DetailedTimer : IComponent
+    public Timer InternalComponent { get; set; }
+    public SegmentTimer SegmentTimer { get; set; }
+    public SimpleLabel LabelSegment { get; set; }
+    public SimpleLabel LabelBest { get; set; }
+    public SimpleLabel SegmentTime { get; set; }
+    public SimpleLabel BestSegmentTime { get; set; }
+    public SimpleLabel SplitName { get; set; }
+    public DetailedTimerSettings Settings { get; set; }
+    public GraphicsCache Cache { get; set; }
+    public string Comparison { get; set; }
+    public string Comparison2 { get; set; }
+    public string ComparisonName { get; set; }
+    public string ComparisonName2 { get; set; }
+    public bool HideComparison { get; set; }
+    protected int FrameCount { get; set; }
+
+    protected int IconWidth { get; set; }
+
+    public Image ShadowImage { get; set; }
+    protected Image OldImage { get; set; }
+
+    public float PaddingTop => 0f;
+    public float PaddingLeft => 7f;
+    public float PaddingBottom => 0f;
+    public float PaddingRight => 7f;
+
+    public float VerticalHeight => Settings.Height;
+
+    public float HorizontalWidth => Settings.Width;
+
+    public float MinimumWidth => 20;
+
+    public float MinimumHeight => 20;
+
+    public IDictionary<string, Action> ContextMenuControls => null;
+
+    private Regex SubsplitRegex = new Regex(@"^{(.+)}\s*(.+)$", RegexOptions.Compiled);
+
+    public DetailedTimer(LiveSplitState state)
     {
-        public Timer InternalComponent { get; set; }
-        public SegmentTimer SegmentTimer { get; set; }
-        public SimpleLabel LabelSegment { get; set; }
-        public SimpleLabel LabelBest { get; set; }
-        public SimpleLabel SegmentTime { get; set; }
-        public SimpleLabel BestSegmentTime { get; set; }
-        public SimpleLabel SplitName { get; set; }
-        public DetailedTimerSettings Settings { get; set; }
-        public GraphicsCache Cache { get; set; }
-        public string Comparison { get; set; }
-        public string Comparison2 { get; set; }
-        public string ComparisonName { get; set; }
-        public string ComparisonName2 { get; set; }
-        public bool HideComparison { get; set; }
-        protected int FrameCount { get; set; }
-
-        protected int IconWidth { get; set; }
-
-        public Image ShadowImage { get; set; }
-        protected Image OldImage { get; set; }
-
-        public float PaddingTop => 0f;
-        public float PaddingLeft => 7f;
-        public float PaddingBottom => 0f;
-        public float PaddingRight => 7f;
-
-        public float VerticalHeight => Settings.Height;
-
-        public float HorizontalWidth => Settings.Width;
-
-        public float MinimumWidth => 20;
-
-        public float MinimumHeight => 20;
-
-        public IDictionary<string, Action> ContextMenuControls => null;
-
-        private Regex SubsplitRegex = new Regex(@"^{(.+)}\s*(.+)$", RegexOptions.Compiled);
-
-        public DetailedTimer(LiveSplitState state)
+        InternalComponent = new LiveSplit.UI.Components.Timer();
+        SegmentTimer = new SegmentTimer();
+        Settings = new DetailedTimerSettings()
         {
-            InternalComponent = new LiveSplit.UI.Components.Timer();
-            SegmentTimer = new SegmentTimer();
-            Settings = new DetailedTimerSettings()
-            {
-                CurrentState = state
-            };
-            IconWidth = 0;
-            Cache = new GraphicsCache();
-            LabelSegment = new SimpleLabel();
-            LabelBest = new SimpleLabel();
-            SegmentTime = new SimpleLabel();
-            BestSegmentTime = new SimpleLabel();
-            SplitName = new SimpleLabel();
-            state.ComparisonRenamed += state_ComparisonRenamed;
+            CurrentState = state
+        };
+        IconWidth = 0;
+        Cache = new GraphicsCache();
+        LabelSegment = new SimpleLabel();
+        LabelBest = new SimpleLabel();
+        SegmentTime = new SimpleLabel();
+        BestSegmentTime = new SimpleLabel();
+        SplitName = new SimpleLabel();
+        state.ComparisonRenamed += state_ComparisonRenamed;
+    }
+
+    void state_ComparisonRenamed(object sender, EventArgs e)
+    {
+        var args = (RenameEventArgs)e;
+        if (Settings.Comparison == args.OldName)
+        {
+            Settings.Comparison = args.NewName;
+            ((LiveSplitState)sender).Layout.HasChanged = true;
         }
-
-        void state_ComparisonRenamed(object sender, EventArgs e)
+        if (Settings.Comparison2 == args.OldName)
         {
-            var args = (RenameEventArgs)e;
-            if (Settings.Comparison == args.OldName)
-            {
-                Settings.Comparison = args.NewName;
-                ((LiveSplitState)sender).Layout.HasChanged = true;
-            }
-            if (Settings.Comparison2 == args.OldName)
-            {
-                Settings.Comparison2 = args.NewName;
-                ((LiveSplitState)sender).Layout.HasChanged = true;
-            }
+            Settings.Comparison2 = args.NewName;
+            ((LiveSplitState)sender).Layout.HasChanged = true;
         }
+    }
 
-        public void DrawGeneral(Graphics g, LiveSplitState state, float width, float height)
+    public void DrawGeneral(Graphics g, LiveSplitState state, float width, float height)
+    {
+        Timer.DrawBackground(g, InternalComponent.TimerColor, Settings.BackgroundColor, Settings.BackgroundColor2, width, height, Settings.BackgroundGradient);
+
+        var lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
+
+        var originalDrawSize = Math.Min(Settings.IconSize, width - 14);
+        var icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
+        if (Settings.DisplayIcon && icon != null)
         {
-            Timer.DrawBackground(g, InternalComponent.TimerColor, Settings.BackgroundColor, Settings.BackgroundColor2, width, height, Settings.BackgroundGradient);
-
-            var lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
-
-            var originalDrawSize = Math.Min(Settings.IconSize, width - 14);
-            var icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
-            if (Settings.DisplayIcon && icon != null)
+            if (OldImage != icon)
             {
-                if (OldImage != icon)
-                {
-                    ImageAnimator.Animate(icon, (s, o) => { });
-                    OldImage = icon;
-                }
-                var drawWidth = originalDrawSize;
-                var drawHeight = originalDrawSize;
-                if (icon.Width > icon.Height)
-                {
-                    var ratio = icon.Height / (float)icon.Width;
-                    drawHeight *= ratio;
-                }
-                else
-                {
-                    var ratio = icon.Width / (float)icon.Height;
-                    drawWidth *= ratio;
-                }
-
-                ImageAnimator.UpdateFrames(icon);
-
-                g.DrawImage(
-                    icon,
-                    7 + (originalDrawSize - drawWidth) / 2,
-                    (height - originalDrawSize) / 2.0f + (originalDrawSize - drawHeight) / 2,
-                    drawWidth,
-                    drawHeight);
-
-                IconWidth = (int)(originalDrawSize + 7.5f);
+                ImageAnimator.Animate(icon, (s, o) => { });
+                OldImage = icon;
+            }
+            var drawWidth = originalDrawSize;
+            var drawHeight = originalDrawSize;
+            if (icon.Width > icon.Height)
+            {
+                var ratio = icon.Height / (float)icon.Width;
+                drawHeight *= ratio;
             }
             else
-                IconWidth = 0;
-
-            InternalComponent.Settings.ShowGradient = Settings.TimerShowGradient;
-            InternalComponent.Settings.OverrideSplitColors = Settings.OverrideTimerColors;
-            InternalComponent.Settings.TimerColor = Settings.TimerColor;
-            InternalComponent.Settings.DigitsFormat = Settings.DigitsFormat;
-            InternalComponent.Settings.Accuracy = Settings.Accuracy;
-            InternalComponent.Settings.DecimalsSize = Settings.DecimalsSize;
-            SegmentTimer.Settings.ShowGradient = Settings.SegmentTimerShowGradient;
-            SegmentTimer.Settings.OverrideSplitColors = true;
-            SegmentTimer.Settings.TimerColor = Settings.SegmentTimerColor;
-            SegmentTimer.Settings.DigitsFormat = Settings.SegmentDigitsFormat;
-            SegmentTimer.Settings.Accuracy = Settings.SegmentAccuracy;
-            SegmentTimer.Settings.DecimalsSize = Settings.SegmentTimerDecimalsSize;
-
-            if (state.CurrentSplitIndex >= 0)
             {
-                var labelsFont = new Font(Settings.SegmentLabelsFont.FontFamily, Settings.SegmentLabelsFont.Size, Settings.SegmentLabelsFont.Style, Settings.SegmentLabelsFont.Unit);
-                var timesFont = new Font(Settings.SegmentTimesFont.FontFamily, Settings.SegmentTimesFont.Size, Settings.SegmentTimesFont.Style, Settings.SegmentTimesFont.Unit);
-                LabelSegment.Font = labelsFont;
-                LabelSegment.X = 5 + IconWidth;
-                LabelSegment.Y = height * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
-                LabelSegment.Width = width - SegmentTimer.ActualWidth - 5 - IconWidth;
-                LabelSegment.Height = height * (Settings.SegmentTimerSizeRatio / 200f) * (!HideComparison ? 1f : 2f);
-                LabelSegment.HorizontalAlignment = StringAlignment.Near;
-                LabelSegment.VerticalAlignment = StringAlignment.Center;
-                LabelSegment.ForeColor = Settings.SegmentLabelsColor;
-                LabelSegment.HasShadow = state.LayoutSettings.DropShadows;
-                LabelSegment.ShadowColor = state.LayoutSettings.ShadowsColor;
-                LabelSegment.OutlineColor = state.LayoutSettings.TextOutlineColor;
-                if (Comparison != "None")
-                    LabelSegment.Draw(g);
-
-                LabelBest.Font = labelsFont;
-                LabelBest.X = 5 + IconWidth;
-                LabelBest.Y = height * ((100f - Settings.SegmentTimerSizeRatio / 2f) / 100f);
-                LabelBest.Width = width - SegmentTimer.ActualWidth - 5 - IconWidth;
-                LabelBest.Height = height * (Settings.SegmentTimerSizeRatio / 200f);
-                LabelBest.HorizontalAlignment = StringAlignment.Near;
-                LabelBest.VerticalAlignment = StringAlignment.Center;
-                LabelBest.ForeColor = Settings.SegmentLabelsColor;
-                LabelBest.HasShadow = state.LayoutSettings.DropShadows;
-                LabelBest.ShadowColor = state.LayoutSettings.ShadowsColor;
-                LabelBest.OutlineColor = state.LayoutSettings.TextOutlineColor;
-                if (!HideComparison)
-                    LabelBest.Draw(g);
-
-                var offset = Math.Max(LabelSegment.ActualWidth, HideComparison ? 0 : LabelBest.ActualWidth) + 10;
-
-                if (Comparison != "None")
-                {
-                    SegmentTime.Font = timesFont;
-                    SegmentTime.X = offset + IconWidth;
-                    SegmentTime.Y = height * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
-                    SegmentTime.Width = width - SegmentTimer.ActualWidth - offset - IconWidth;
-                    SegmentTime.Height = height * (Settings.SegmentTimerSizeRatio / 200f) * (!HideComparison ? 1f : 2f);
-                    SegmentTime.HorizontalAlignment = StringAlignment.Near;
-                    SegmentTime.VerticalAlignment = StringAlignment.Center;
-                    SegmentTime.ForeColor = Settings.SegmentTimesColor;
-                    SegmentTime.HasShadow = state.LayoutSettings.DropShadows;
-                    SegmentTime.ShadowColor = state.LayoutSettings.ShadowsColor;
-                    SegmentTime.OutlineColor = state.LayoutSettings.TextOutlineColor;
-                    SegmentTime.IsMonospaced = true;
-                    SegmentTime.Draw(g);
-                }
-
-                if (!HideComparison)
-                {
-                    BestSegmentTime.Font = timesFont;
-                    BestSegmentTime.X = offset + IconWidth;
-                    BestSegmentTime.Y = height * ((100f - Settings.SegmentTimerSizeRatio / 2f) / 100f);
-                    BestSegmentTime.Width = width - SegmentTimer.ActualWidth - offset - IconWidth;
-                    BestSegmentTime.Height = height * (Settings.SegmentTimerSizeRatio / 200f);
-                    BestSegmentTime.HorizontalAlignment = StringAlignment.Near;
-                    BestSegmentTime.VerticalAlignment = StringAlignment.Center;
-                    BestSegmentTime.ForeColor = Settings.SegmentTimesColor;
-                    BestSegmentTime.HasShadow = state.LayoutSettings.DropShadows;
-                    BestSegmentTime.ShadowColor = state.LayoutSettings.ShadowsColor;
-                    BestSegmentTime.OutlineColor = state.LayoutSettings.TextOutlineColor;
-                    BestSegmentTime.IsMonospaced = true;
-                    BestSegmentTime.Draw(g);
-                }
-                SplitName.Font = Settings.SplitNameFont;
-                SplitName.X = IconWidth + 5;
-                SplitName.Y = 0;
-                SplitName.Width = width - InternalComponent.ActualWidth - IconWidth - 5;
-                SplitName.Height = height * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
-                SplitName.HorizontalAlignment = StringAlignment.Near;
-                SplitName.VerticalAlignment = StringAlignment.Center;
-                SplitName.ForeColor = Settings.SplitNameColor;
-                SplitName.HasShadow = state.LayoutSettings.DropShadows;
-                SplitName.ShadowColor = state.LayoutSettings.ShadowsColor;
-                SplitName.OutlineColor = state.LayoutSettings.TextOutlineColor;
-                if (Settings.ShowSplitName)
-                    SplitName.Draw(g);
+                var ratio = icon.Width / (float)icon.Height;
+                drawWidth *= ratio;
             }
+
+            ImageAnimator.UpdateFrames(icon);
+
+            g.DrawImage(
+                icon,
+                7 + (originalDrawSize - drawWidth) / 2,
+                (height - originalDrawSize) / 2.0f + (originalDrawSize - drawHeight) / 2,
+                drawWidth,
+                drawHeight);
+
+            IconWidth = (int)(originalDrawSize + 7.5f);
         }
+        else
+            IconWidth = 0;
 
-        public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
+        InternalComponent.Settings.ShowGradient = Settings.TimerShowGradient;
+        InternalComponent.Settings.OverrideSplitColors = Settings.OverrideTimerColors;
+        InternalComponent.Settings.TimerColor = Settings.TimerColor;
+        InternalComponent.Settings.DigitsFormat = Settings.DigitsFormat;
+        InternalComponent.Settings.Accuracy = Settings.Accuracy;
+        InternalComponent.Settings.DecimalsSize = Settings.DecimalsSize;
+        SegmentTimer.Settings.ShowGradient = Settings.SegmentTimerShowGradient;
+        SegmentTimer.Settings.OverrideSplitColors = true;
+        SegmentTimer.Settings.TimerColor = Settings.SegmentTimerColor;
+        SegmentTimer.Settings.DigitsFormat = Settings.SegmentDigitsFormat;
+        SegmentTimer.Settings.Accuracy = Settings.SegmentAccuracy;
+        SegmentTimer.Settings.DecimalsSize = Settings.SegmentTimerDecimalsSize;
+
+        if (state.CurrentSplitIndex >= 0)
         {
-            DrawGeneral(g, state, width, VerticalHeight);
-            var oldMatrix = g.Transform;
-            InternalComponent.Settings.TimerHeight = VerticalHeight * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
-            InternalComponent.DrawVertical(g, state, width, clipRegion);
-            g.Transform = oldMatrix;
-            g.TranslateTransform(0, VerticalHeight * ((100f - Settings.SegmentTimerSizeRatio) / 100f));
-            SegmentTimer.Settings.TimerHeight = VerticalHeight * (Settings.SegmentTimerSizeRatio / 100f);
-            SegmentTimer.DrawVertical(g, state, width, clipRegion);
-            g.Transform = oldMatrix;
-        }
+            var labelsFont = new Font(Settings.SegmentLabelsFont.FontFamily, Settings.SegmentLabelsFont.Size, Settings.SegmentLabelsFont.Style, Settings.SegmentLabelsFont.Unit);
+            var timesFont = new Font(Settings.SegmentTimesFont.FontFamily, Settings.SegmentTimesFont.Size, Settings.SegmentTimesFont.Style, Settings.SegmentTimesFont.Unit);
+            LabelSegment.Font = labelsFont;
+            LabelSegment.X = 5 + IconWidth;
+            LabelSegment.Y = height * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
+            LabelSegment.Width = width - SegmentTimer.ActualWidth - 5 - IconWidth;
+            LabelSegment.Height = height * (Settings.SegmentTimerSizeRatio / 200f) * (!HideComparison ? 1f : 2f);
+            LabelSegment.HorizontalAlignment = StringAlignment.Near;
+            LabelSegment.VerticalAlignment = StringAlignment.Center;
+            LabelSegment.ForeColor = Settings.SegmentLabelsColor;
+            LabelSegment.HasShadow = state.LayoutSettings.DropShadows;
+            LabelSegment.ShadowColor = state.LayoutSettings.ShadowsColor;
+            LabelSegment.OutlineColor = state.LayoutSettings.TextOutlineColor;
+            if (Comparison != "None")
+                LabelSegment.Draw(g);
 
-        public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
-        {
-            DrawGeneral(g, state, HorizontalWidth, height);
-            var oldMatrix = g.Transform;
-            InternalComponent.Settings.TimerWidth = HorizontalWidth;
-            InternalComponent.DrawHorizontal(g, state, height * ((100f - Settings.SegmentTimerSizeRatio) / 100f), clipRegion);
-            g.Transform = oldMatrix;
-            g.TranslateTransform(0, height * ((100f - Settings.SegmentTimerSizeRatio) / 100f));
-            SegmentTimer.DrawHorizontal(g, state, height * (Settings.SegmentTimerSizeRatio / 100f), clipRegion);
-            SegmentTimer.Settings.TimerWidth = HorizontalWidth;
-            g.Transform = oldMatrix;
-        }
+            LabelBest.Font = labelsFont;
+            LabelBest.X = 5 + IconWidth;
+            LabelBest.Y = height * ((100f - Settings.SegmentTimerSizeRatio / 2f) / 100f);
+            LabelBest.Width = width - SegmentTimer.ActualWidth - 5 - IconWidth;
+            LabelBest.Height = height * (Settings.SegmentTimerSizeRatio / 200f);
+            LabelBest.HorizontalAlignment = StringAlignment.Near;
+            LabelBest.VerticalAlignment = StringAlignment.Center;
+            LabelBest.ForeColor = Settings.SegmentLabelsColor;
+            LabelBest.HasShadow = state.LayoutSettings.DropShadows;
+            LabelBest.ShadowColor = state.LayoutSettings.ShadowsColor;
+            LabelBest.OutlineColor = state.LayoutSettings.TextOutlineColor;
+            if (!HideComparison)
+                LabelBest.Draw(g);
 
-        public string ComponentName => "Detailed Timer";
+            var offset = Math.Max(LabelSegment.ActualWidth, HideComparison ? 0 : LabelBest.ActualWidth) + 10;
 
-        public Control GetSettingsControl(LayoutMode mode)
-        {
-            Settings.Mode = mode;
-            return Settings;
-        }
-
-        public void SetSettings(XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
-        {
-            var lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
-            var Formatter = Settings.SegmentTimesFormatter;
-            var timingMethod = state.CurrentTimingMethod;
-            if (Settings.TimingMethod == "Real Time")
-                timingMethod = TimingMethod.RealTime;
-            else if (Settings.TimingMethod == "Game Time")
-                timingMethod = TimingMethod.GameTime;
-
-            if (state.CurrentSplitIndex >= 0)
+            if (Comparison != "None")
             {
-                Comparison = Settings.Comparison == "Current Comparison" ? state.CurrentComparison : Settings.Comparison;
-                Comparison2 = Settings.Comparison2 == "Current Comparison" ? state.CurrentComparison : Settings.Comparison2;
-                HideComparison = Settings.HideComparison;
+                SegmentTime.Font = timesFont;
+                SegmentTime.X = offset + IconWidth;
+                SegmentTime.Y = height * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
+                SegmentTime.Width = width - SegmentTimer.ActualWidth - offset - IconWidth;
+                SegmentTime.Height = height * (Settings.SegmentTimerSizeRatio / 200f) * (!HideComparison ? 1f : 2f);
+                SegmentTime.HorizontalAlignment = StringAlignment.Near;
+                SegmentTime.VerticalAlignment = StringAlignment.Center;
+                SegmentTime.ForeColor = Settings.SegmentTimesColor;
+                SegmentTime.HasShadow = state.LayoutSettings.DropShadows;
+                SegmentTime.ShadowColor = state.LayoutSettings.ShadowsColor;
+                SegmentTime.OutlineColor = state.LayoutSettings.TextOutlineColor;
+                SegmentTime.IsMonospaced = true;
+                SegmentTime.Draw(g);
+            }
 
-                if (HideComparison || !state.Run.Comparisons.Contains(Comparison2) || Comparison2 == "None")
-                {
-                    HideComparison = true;
-                    if (!state.Run.Comparisons.Contains(Comparison) || Comparison == "None")
-                        Comparison = state.CurrentComparison;
-                }
-                else if (!state.Run.Comparisons.Contains(Comparison) || Comparison == "None")
-                {
-                    HideComparison = true;
-                    Comparison = Comparison2;
-                }
-                else if (Comparison == Comparison2)
-                    HideComparison = true;
+            if (!HideComparison)
+            {
+                BestSegmentTime.Font = timesFont;
+                BestSegmentTime.X = offset + IconWidth;
+                BestSegmentTime.Y = height * ((100f - Settings.SegmentTimerSizeRatio / 2f) / 100f);
+                BestSegmentTime.Width = width - SegmentTimer.ActualWidth - offset - IconWidth;
+                BestSegmentTime.Height = height * (Settings.SegmentTimerSizeRatio / 200f);
+                BestSegmentTime.HorizontalAlignment = StringAlignment.Near;
+                BestSegmentTime.VerticalAlignment = StringAlignment.Center;
+                BestSegmentTime.ForeColor = Settings.SegmentTimesColor;
+                BestSegmentTime.HasShadow = state.LayoutSettings.DropShadows;
+                BestSegmentTime.ShadowColor = state.LayoutSettings.ShadowsColor;
+                BestSegmentTime.OutlineColor = state.LayoutSettings.TextOutlineColor;
+                BestSegmentTime.IsMonospaced = true;
+                BestSegmentTime.Draw(g);
+            }
+            SplitName.Font = Settings.SplitNameFont;
+            SplitName.X = IconWidth + 5;
+            SplitName.Y = 0;
+            SplitName.Width = width - InternalComponent.ActualWidth - IconWidth - 5;
+            SplitName.Height = height * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
+            SplitName.HorizontalAlignment = StringAlignment.Near;
+            SplitName.VerticalAlignment = StringAlignment.Center;
+            SplitName.ForeColor = Settings.SplitNameColor;
+            SplitName.HasShadow = state.LayoutSettings.DropShadows;
+            SplitName.ShadowColor = state.LayoutSettings.ShadowsColor;
+            SplitName.OutlineColor = state.LayoutSettings.TextOutlineColor;
+            if (Settings.ShowSplitName)
+                SplitName.Draw(g);
+        }
+    }
 
-                ComparisonName = CompositeComparisons.GetShortComparisonName(Comparison);
-                ComparisonName2 = CompositeComparisons.GetShortComparisonName(Comparison2);
+    public void DrawVertical(Graphics g, LiveSplitState state, float width, Region clipRegion)
+    {
+        DrawGeneral(g, state, width, VerticalHeight);
+        var oldMatrix = g.Transform;
+        InternalComponent.Settings.TimerHeight = VerticalHeight * ((100f - Settings.SegmentTimerSizeRatio) / 100f);
+        InternalComponent.DrawVertical(g, state, width, clipRegion);
+        g.Transform = oldMatrix;
+        g.TranslateTransform(0, VerticalHeight * ((100f - Settings.SegmentTimerSizeRatio) / 100f));
+        SegmentTimer.Settings.TimerHeight = VerticalHeight * (Settings.SegmentTimerSizeRatio / 100f);
+        SegmentTimer.DrawVertical(g, state, width, clipRegion);
+        g.Transform = oldMatrix;
+    }
 
-                TimeSpan? segmentTime = null;
+    public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)
+    {
+        DrawGeneral(g, state, HorizontalWidth, height);
+        var oldMatrix = g.Transform;
+        InternalComponent.Settings.TimerWidth = HorizontalWidth;
+        InternalComponent.DrawHorizontal(g, state, height * ((100f - Settings.SegmentTimerSizeRatio) / 100f), clipRegion);
+        g.Transform = oldMatrix;
+        g.TranslateTransform(0, height * ((100f - Settings.SegmentTimerSizeRatio) / 100f));
+        SegmentTimer.DrawHorizontal(g, state, height * (Settings.SegmentTimerSizeRatio / 100f), clipRegion);
+        SegmentTimer.Settings.TimerWidth = HorizontalWidth;
+        g.Transform = oldMatrix;
+    }
 
-                if (Comparison == BestSegmentsComparisonGenerator.ComparisonName)
-                    segmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].BestSegmentTime[timingMethod];
+    public string ComponentName => "Detailed Timer";
+
+    public Control GetSettingsControl(LayoutMode mode)
+    {
+        Settings.Mode = mode;
+        return Settings;
+    }
+
+    public void SetSettings(XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+    public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
+    {
+        var lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
+        var Formatter = Settings.SegmentTimesFormatter;
+        var timingMethod = state.CurrentTimingMethod;
+        if (Settings.TimingMethod == "Real Time")
+            timingMethod = TimingMethod.RealTime;
+        else if (Settings.TimingMethod == "Game Time")
+            timingMethod = TimingMethod.GameTime;
+
+        if (state.CurrentSplitIndex >= 0)
+        {
+            Comparison = Settings.Comparison == "Current Comparison" ? state.CurrentComparison : Settings.Comparison;
+            Comparison2 = Settings.Comparison2 == "Current Comparison" ? state.CurrentComparison : Settings.Comparison2;
+            HideComparison = Settings.HideComparison;
+
+            if (HideComparison || !state.Run.Comparisons.Contains(Comparison2) || Comparison2 == "None")
+            {
+                HideComparison = true;
+                if (!state.Run.Comparisons.Contains(Comparison) || Comparison == "None")
+                    Comparison = state.CurrentComparison;
+            }
+            else if (!state.Run.Comparisons.Contains(Comparison) || Comparison == "None")
+            {
+                HideComparison = true;
+                Comparison = Comparison2;
+            }
+            else if (Comparison == Comparison2)
+                HideComparison = true;
+
+            ComparisonName = CompositeComparisons.GetShortComparisonName(Comparison);
+            ComparisonName2 = CompositeComparisons.GetShortComparisonName(Comparison2);
+
+            TimeSpan? segmentTime = null;
+
+            if (Comparison == BestSegmentsComparisonGenerator.ComparisonName)
+                segmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].BestSegmentTime[timingMethod];
+            else
+            {
+                if (state.CurrentSplitIndex == 0 || (state.CurrentSplitIndex == 1 && lastSplitOffset == -1))
+                    segmentTime = state.Run[0].Comparisons[Comparison][timingMethod];
+                else if (state.CurrentSplitIndex > 0)
+                    segmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].Comparisons[Comparison][timingMethod]
+                        - state.Run[state.CurrentSplitIndex - 1 + lastSplitOffset].Comparisons[Comparison][timingMethod];
+            }
+
+            LabelSegment.Text = ComparisonName + ":";
+
+            LabelBest.Text = ComparisonName2 + ":";
+
+            if (Comparison != "None")
+            {
+                SegmentTime.Text = Formatter.Format(segmentTime);
+            }
+
+            if (!HideComparison)
+            {
+                TimeSpan? bestSegmentTime = null;
+                if (Comparison2 == BestSegmentsComparisonGenerator.ComparisonName)
+                    bestSegmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].BestSegmentTime[timingMethod];
                 else
                 {
                     if (state.CurrentSplitIndex == 0 || (state.CurrentSplitIndex == 1 && lastSplitOffset == -1))
-                        segmentTime = state.Run[0].Comparisons[Comparison][timingMethod];
+                        bestSegmentTime = state.Run[0].Comparisons[Comparison2][timingMethod];
                     else if (state.CurrentSplitIndex > 0)
-                        segmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].Comparisons[Comparison][timingMethod]
-                            - state.Run[state.CurrentSplitIndex - 1 + lastSplitOffset].Comparisons[Comparison][timingMethod];
+                        bestSegmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].Comparisons[Comparison2][timingMethod]
+                            - state.Run[state.CurrentSplitIndex - 1 + lastSplitOffset].Comparisons[Comparison2][timingMethod];
                 }
 
-                LabelSegment.Text = ComparisonName + ":";
+                BestSegmentTime.Text = Formatter.Format(bestSegmentTime);
+            }
+            if (state.CurrentSplitIndex >= 0)
+            {
+                string name = state.Run[state.CurrentSplitIndex + lastSplitOffset].Name;
 
-                LabelBest.Text = ComparisonName2 + ":";
+                bool isSubsplit = name.StartsWith("-") && state.CurrentSplitIndex + lastSplitOffset < state.Run.Count - 1;
 
-                if (Comparison != "None")
+                if (isSubsplit)
+                    SplitName.Text = name.Substring(1);
+                else
                 {
-                    SegmentTime.Text = Formatter.Format(segmentTime);
-                }
-
-                if (!HideComparison)
-                {
-                    TimeSpan? bestSegmentTime = null;
-                    if (Comparison2 == BestSegmentsComparisonGenerator.ComparisonName)
-                        bestSegmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].BestSegmentTime[timingMethod];
+                    Match match = SubsplitRegex.Match(name);
+                    if (match.Success)
+                        SplitName.Text = match.Groups[2].Value;
                     else
-                    {
-                        if (state.CurrentSplitIndex == 0 || (state.CurrentSplitIndex == 1 && lastSplitOffset == -1))
-                            bestSegmentTime = state.Run[0].Comparisons[Comparison2][timingMethod];
-                        else if (state.CurrentSplitIndex > 0)
-                            bestSegmentTime = state.Run[state.CurrentSplitIndex + lastSplitOffset].Comparisons[Comparison2][timingMethod]
-                                - state.Run[state.CurrentSplitIndex - 1 + lastSplitOffset].Comparisons[Comparison2][timingMethod];
-                    }
-
-                    BestSegmentTime.Text = Formatter.Format(bestSegmentTime);
+                        SplitName.Text = name;
                 }
-                if (state.CurrentSplitIndex >= 0)
-                {
-                    string name = state.Run[state.CurrentSplitIndex + lastSplitOffset].Name;
-
-                    bool isSubsplit = name.StartsWith("-") && state.CurrentSplitIndex + lastSplitOffset < state.Run.Count - 1;
-
-                    if (isSubsplit)
-                        SplitName.Text = name.Substring(1);
-                    else
-                    {
-                        Match match = SubsplitRegex.Match(name);
-                        if (match.Success)
-                            SplitName.Text = match.Groups[2].Value;
-                        else
-                            SplitName.Text = name;
-                    }
-                }
-                else
-                    SplitName.Text = "";
             }
-
-            SegmentTimer.Settings.TimingMethod = Settings.TimingMethod;
-            InternalComponent.Settings.TimingMethod = Settings.TimingMethod;
-            SegmentTimer.Update(null, state, width, height, mode);
-            InternalComponent.Update(null, state, width, height, mode);
-
-            var icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
-
-            Cache.Restart();
-            Cache["SplitIcon"] = icon;
-            if (Cache.HasChanged)
-            {
-                if (icon == null)
-                    FrameCount = 0;
-                else
-                    FrameCount = icon.GetFrameCount(new FrameDimension(icon.FrameDimensionsList[0]));
-            }
-            Cache["SplitName"] = SplitName.Text;
-            Cache["LabelSegment"] = LabelSegment.Text;
-            Cache["LabelBest"] = LabelBest.Text;
-            Cache["SegmentTime"] = SegmentTime.Text;
-            Cache["BestSegmentTime"] = BestSegmentTime.Text;
-            Cache["SegmentTimerText"] = SegmentTimer.BigTextLabel.Text + SegmentTimer.SmallTextLabel.Text;
-            Cache["InternalComponentText"] = InternalComponent.BigTextLabel.Text + InternalComponent.SmallTextLabel.Text;
-            if (InternalComponent.BigTextLabel.Brush != null && invalidator != null)
-            {
-                if (InternalComponent.BigTextLabel.Brush is LinearGradientBrush)
-                    Cache["TimerColor"] = ((LinearGradientBrush)InternalComponent.BigTextLabel.Brush).LinearColors.First().ToArgb();
-                else
-                    Cache["TimerColor"] = InternalComponent.BigTextLabel.ForeColor.ToArgb();
-            }
-
-            if (invalidator != null && (Cache.HasChanged || FrameCount > 1))
-            {
-                invalidator.Invalidate(0, 0, width, height);
-            }
+            else
+                SplitName.Text = "";
         }
 
-        public void Dispose()
+        SegmentTimer.Settings.TimingMethod = Settings.TimingMethod;
+        InternalComponent.Settings.TimingMethod = Settings.TimingMethod;
+        SegmentTimer.Update(null, state, width, height, mode);
+        InternalComponent.Update(null, state, width, height, mode);
+
+        var icon = state.CurrentSplitIndex >= 0 ? state.Run[state.CurrentSplitIndex + lastSplitOffset].Icon : null;
+
+        Cache.Restart();
+        Cache["SplitIcon"] = icon;
+        if (Cache.HasChanged)
         {
+            if (icon == null)
+                FrameCount = 0;
+            else
+                FrameCount = icon.GetFrameCount(new FrameDimension(icon.FrameDimensionsList[0]));
+        }
+        Cache["SplitName"] = SplitName.Text;
+        Cache["LabelSegment"] = LabelSegment.Text;
+        Cache["LabelBest"] = LabelBest.Text;
+        Cache["SegmentTime"] = SegmentTime.Text;
+        Cache["BestSegmentTime"] = BestSegmentTime.Text;
+        Cache["SegmentTimerText"] = SegmentTimer.BigTextLabel.Text + SegmentTimer.SmallTextLabel.Text;
+        Cache["InternalComponentText"] = InternalComponent.BigTextLabel.Text + InternalComponent.SmallTextLabel.Text;
+        if (InternalComponent.BigTextLabel.Brush != null && invalidator != null)
+        {
+            if (InternalComponent.BigTextLabel.Brush is LinearGradientBrush)
+                Cache["TimerColor"] = ((LinearGradientBrush)InternalComponent.BigTextLabel.Brush).LinearColors.First().ToArgb();
+            else
+                Cache["TimerColor"] = InternalComponent.BigTextLabel.ForeColor.ToArgb();
         }
 
-        public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+        if (invalidator != null && (Cache.HasChanged || FrameCount > 1))
+        {
+            invalidator.Invalidate(0, 0, width, height);
+        }
     }
+
+    public void Dispose()
+    {
+    }
+
+    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
 }

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -10,6 +10,7 @@ using System.Xml;
 
 using LiveSplit.Model;
 using LiveSplit.Model.Comparisons;
+using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
@@ -282,7 +283,7 @@ public class DetailedTimer : IComponent
     public void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode)
     {
         int lastSplitOffset = state.CurrentSplitIndex == state.Run.Count ? -1 : 0;
-        TimeFormatters.GeneralTimeFormatter Formatter = Settings.SegmentTimesFormatter;
+        GeneralTimeFormatter formatter = Settings.SegmentTimesFormatter;
         TimingMethod timingMethod = state.CurrentTimingMethod;
         if (Settings.TimingMethod == "Real Time")
         {
@@ -345,7 +346,7 @@ public class DetailedTimer : IComponent
 
             if (Comparison != "None")
             {
-                SegmentTime.Text = Formatter.Format(segmentTime);
+                SegmentTime.Text = formatter.Format(segmentTime);
             }
 
             if (!HideComparison)
@@ -368,7 +369,7 @@ public class DetailedTimer : IComponent
                     }
                 }
 
-                BestSegmentTime.Text = Formatter.Format(bestSegmentTime);
+                BestSegmentTime.Text = formatter.Format(bestSegmentTime);
             }
 
             if (state.CurrentSplitIndex >= 0)

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -55,7 +55,7 @@ public class DetailedTimer : IComponent
 
     public DetailedTimer(LiveSplitState state)
     {
-        InternalComponent = new LiveSplit.UI.Components.Timer();
+        InternalComponent = new Timer();
         SegmentTimer = new SegmentTimer();
         Settings = new DetailedTimerSettings()
         {

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -430,9 +430,9 @@ public class DetailedTimer : IComponent
         Cache["InternalComponentText"] = InternalComponent.BigTextLabel.Text + InternalComponent.SmallTextLabel.Text;
         if (InternalComponent.BigTextLabel.Brush != null && invalidator != null)
         {
-            if (InternalComponent.BigTextLabel.Brush is LinearGradientBrush)
+            if (InternalComponent.BigTextLabel.Brush is LinearGradientBrush brush)
             {
-                Cache["TimerColor"] = ((LinearGradientBrush)InternalComponent.BigTextLabel.Brush).LinearColors.First().ToArgb();
+                Cache["TimerColor"] = brush.LinearColors.First().ToArgb();
             }
             else
             {

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerFactory.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerFactory.cs
@@ -15,7 +15,10 @@ public class DetailedTimerFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Timer;
 
-    public IComponent Create(LiveSplitState state) => new DetailedTimer(state);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new DetailedTimer(state);
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerFactory.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerFactory.cs
@@ -1,27 +1,27 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(DetailedTimerFactory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class DetailedTimerFactory : IComponentFactory
 {
-    public class DetailedTimerFactory : IComponentFactory
-    {
-        public string ComponentName => "Detailed Timer";
+    public string ComponentName => "Detailed Timer";
 
-        public string Description => "Displays the run timer, segment timer, and segment times for up to two comparisons.";
+    public string Description => "Displays the run timer, segment timer, and segment times for up to two comparisons.";
 
-        public ComponentCategory Category => ComponentCategory.Timer;
+    public ComponentCategory Category => ComponentCategory.Timer;
 
-        public IComponent Create(LiveSplitState state) => new DetailedTimer(state);
+    public IComponent Create(LiveSplitState state) => new DetailedTimer(state);
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.DetailedTimer.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.DetailedTimer.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
-    }
+    public Version Version => Version.Parse("1.8.29");
 }

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -1,468 +1,468 @@
-﻿using LiveSplit.Model;
-using LiveSplit.Model.Comparisons;
-using LiveSplit.TimeFormatters;
-using System;
+﻿using System;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+using LiveSplit.Model.Comparisons;
+using LiveSplit.TimeFormatters;
+
+namespace LiveSplit.UI.Components;
+
+public partial class DetailedTimerSettings : UserControl
 {
-    public partial class DetailedTimerSettings : UserControl
+    public float Height { get; set; }
+    public float Width { get; set; }
+    public float SegmentTimerSizeRatio { get; set; }
+    public LiveSplitState CurrentState { get; set; }
+
+    public bool TimerShowGradient { get; set; }
+    public bool OverrideTimerColors { get; set; }
+    public bool SegmentTimerShowGradient { get; set; }
+    public bool ShowSplitName { get; set; }
+
+    public float IconSize { get; set; }
+    public bool DisplayIcon { get; set; }
+
+    public float DecimalsSize { get; set; }
+    public float SegmentTimerDecimalsSize { get; set; }
+
+    public Color TimerColor { get; set; }
+    public Color SegmentTimerColor { get; set; }
+    public Color SegmentLabelsColor { get; set; }
+    public Color SegmentTimesColor { get; set; }
+    public Color SplitNameColor { get; set; }
+
+    public Color BackgroundColor { get; set; }
+    public Color BackgroundColor2 { get; set; }
+
+    public DeltasGradientType BackgroundGradient { get; set; }
+    public string GradientString
     {
-        public float Height { get; set; }
-        public float Width { get; set; }
-        public float SegmentTimerSizeRatio { get; set; }
-        public LiveSplitState CurrentState { get; set; }
-
-        public bool TimerShowGradient { get; set; }
-        public bool OverrideTimerColors { get; set; }
-        public bool SegmentTimerShowGradient { get; set; }
-        public bool ShowSplitName { get; set; }
-
-        public float IconSize { get; set; }
-        public bool DisplayIcon { get; set; }
-
-        public float DecimalsSize { get; set; }
-        public float SegmentTimerDecimalsSize { get; set; }
-
-        public Color TimerColor { get; set; }
-        public Color SegmentTimerColor { get; set; }
-        public Color SegmentLabelsColor { get; set; }
-        public Color SegmentTimesColor { get; set; }
-        public Color SplitNameColor { get; set; }
-
-        public Color BackgroundColor { get; set; }
-        public Color BackgroundColor2 { get; set; }
-
-        public DeltasGradientType BackgroundGradient { get; set; }
-        public string GradientString
+        get { return TimerSettings.GetBackgroundTypeString(BackgroundGradient); }
+        set { BackgroundGradient = (DeltasGradientType)Enum.Parse(typeof(DeltasGradientType), value.Replace(" ", "")); }
+    }
+    private string timerFormat
+    {
+        get
         {
-            get { return TimerSettings.GetBackgroundTypeString(BackgroundGradient); }
-            set { BackgroundGradient = (DeltasGradientType)Enum.Parse(typeof(DeltasGradientType), value.Replace(" ", "")); }
+            return DigitsFormat + Accuracy;
         }
-        private string timerFormat
+        set
         {
-            get
+            var decimalIndex = value.IndexOf('.');
+            if (decimalIndex < 0)
             {
-                return DigitsFormat + Accuracy;
+                DigitsFormat = value;
+                Accuracy = "";
             }
-            set
+            else
             {
-                var decimalIndex = value.IndexOf('.');
-                if (decimalIndex < 0)
-                {
-                    DigitsFormat = value;
-                    Accuracy = "";
-                }
-                else
-                {
-                    DigitsFormat = value.Substring(0, decimalIndex);
-                    Accuracy = value.Substring(decimalIndex);
-                }
+                DigitsFormat = value.Substring(0, decimalIndex);
+                Accuracy = value.Substring(decimalIndex);
             }
         }
-        public string DigitsFormat { get; set; }
-        public string Accuracy { get; set; }
-        private string segmentTimerFormat
+    }
+    public string DigitsFormat { get; set; }
+    public string Accuracy { get; set; }
+    private string segmentTimerFormat
+    {
+        get
         {
-            get
+            return SegmentDigitsFormat + SegmentAccuracy;
+        }
+        set
+        {
+            var decimalIndex = value.IndexOf('.');
+            if (decimalIndex < 0)
             {
-                return SegmentDigitsFormat + SegmentAccuracy;
+                SegmentDigitsFormat = value;
+                SegmentAccuracy = "";
             }
-            set
+            else
             {
-                var decimalIndex = value.IndexOf('.');
-                if (decimalIndex < 0)
-                {
-                    SegmentDigitsFormat = value;
-                    SegmentAccuracy = "";
-                }
-                else
-                {
-                    SegmentDigitsFormat = value.Substring(0, decimalIndex);
-                    SegmentAccuracy = value.Substring(decimalIndex);
-                }
+                SegmentDigitsFormat = value.Substring(0, decimalIndex);
+                SegmentAccuracy = value.Substring(decimalIndex);
             }
         }
-        public string SegmentDigitsFormat { get; set; }
-        public string SegmentAccuracy { get; set; }
-        public TimeAccuracy SegmentTimesAccuracy { get; set; }
-        public GeneralTimeFormatter SegmentTimesFormatter { get; set; } = new GeneralTimeFormatter()
-        {
-            NullFormat = NullFormat.Dash,
-            Accuracy = TimeAccuracy.Hundredths
-        };
-        public string SegmentLabelsFontString => SettingsHelper.FormatFont(SegmentLabelsFont);
-        public Font SegmentLabelsFont { get; set; }
-        public string SegmentTimesFontString => SettingsHelper.FormatFont(SegmentTimesFont);
-        public Font SegmentTimesFont { get; set; }
-        public string SplitNameFontString => SettingsHelper.FormatFont(SplitNameFont);
-        public Font SplitNameFont { get; set; }
+    }
+    public string SegmentDigitsFormat { get; set; }
+    public string SegmentAccuracy { get; set; }
+    public TimeAccuracy SegmentTimesAccuracy { get; set; }
+    public GeneralTimeFormatter SegmentTimesFormatter { get; set; } = new GeneralTimeFormatter()
+    {
+        NullFormat = NullFormat.Dash,
+        Accuracy = TimeAccuracy.Hundredths
+    };
+    public string SegmentLabelsFontString => SettingsHelper.FormatFont(SegmentLabelsFont);
+    public Font SegmentLabelsFont { get; set; }
+    public string SegmentTimesFontString => SettingsHelper.FormatFont(SegmentTimesFont);
+    public Font SegmentTimesFont { get; set; }
+    public string SplitNameFontString => SettingsHelper.FormatFont(SplitNameFont);
+    public Font SplitNameFont { get; set; }
 
-        public string Comparison { get; set; }
-        public string Comparison2 { get; set; }
-        public bool HideComparison { get; set; }
-        public string TimingMethod { get; set; }
+    public string Comparison { get; set; }
+    public string Comparison2 { get; set; }
+    public bool HideComparison { get; set; }
+    public string TimingMethod { get; set; }
 
-        public LayoutMode Mode { get; set; }
+    public LayoutMode Mode { get; set; }
 
-        public DetailedTimerSettings()
-        {
-            InitializeComponent();
+    public DetailedTimerSettings()
+    {
+        InitializeComponent();
 
-            Height = 75;
-            Width = 200;
-            SegmentTimerSizeRatio = 40;
+        Height = 75;
+        Width = 200;
+        SegmentTimerSizeRatio = 40;
 
-            TimerShowGradient = true;
-            OverrideTimerColors = false;
-            SegmentTimerShowGradient = true;
-            ShowSplitName = false;
+        TimerShowGradient = true;
+        OverrideTimerColors = false;
+        SegmentTimerShowGradient = true;
+        ShowSplitName = false;
 
-            TimerColor = Color.FromArgb(170, 170, 170);
-            SegmentTimerColor = Color.FromArgb(170, 170, 170);
-            SegmentLabelsColor = Color.FromArgb(255, 255, 255);
-            SegmentTimesColor = Color.FromArgb(255, 255, 255);
-            SplitNameColor = Color.FromArgb(255, 255, 255);
+        TimerColor = Color.FromArgb(170, 170, 170);
+        SegmentTimerColor = Color.FromArgb(170, 170, 170);
+        SegmentLabelsColor = Color.FromArgb(255, 255, 255);
+        SegmentTimesColor = Color.FromArgb(255, 255, 255);
+        SplitNameColor = Color.FromArgb(255, 255, 255);
 
-            DigitsFormat = "1";
-            Accuracy = ".23";
-            SegmentDigitsFormat = "1";
-            SegmentAccuracy = ".23";
+        DigitsFormat = "1";
+        Accuracy = ".23";
+        SegmentDigitsFormat = "1";
+        SegmentAccuracy = ".23";
+        SegmentTimesAccuracy = TimeAccuracy.Hundredths;
+
+        SegmentLabelsFont = new Font("Segoe UI", 13, FontStyle.Regular, GraphicsUnit.Pixel);
+        SegmentTimesFont = new Font("Segoe UI", 13, FontStyle.Bold, GraphicsUnit.Pixel);
+        SplitNameFont = new Font("Segoe UI", 15, FontStyle.Regular, GraphicsUnit.Pixel);
+
+        BackgroundColor = Color.Transparent;
+        BackgroundColor2 = Color.Transparent;
+        BackgroundGradient = DeltasGradientType.Plain;
+
+        IconSize = 40f;
+        DisplayIcon = false;
+
+        DecimalsSize = 35f;
+        SegmentTimerDecimalsSize = 35f;
+
+        Comparison = "Current Comparison";
+        Comparison2 = "Best Segments";
+        HideComparison = false;
+        TimingMethod = "Current Timing Method";
+
+        chkShowGradientSegmentTimer.DataBindings.Add("Checked", this, "SegmentTimerShowGradient", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkShowGradientTimer.DataBindings.Add("Checked", this, "TimerShowGradient", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkOverrideTimerColors.DataBindings.Add("Checked", this, "OverrideTimerColors", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkSplitName.DataBindings.Add("Checked", this, "ShowSplitName", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnTimerColor.DataBindings.Add("BackColor", this, "TimerColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnSegmentTimerColor.DataBindings.Add("BackColor", this, "SegmentTimerColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnSegmentLabelsColor.DataBindings.Add("BackColor", this, "SegmentLabelsColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnSegmentTimesColor.DataBindings.Add("BackColor", this, "SegmentTimesColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnSplitNameColor.DataBindings.Add("BackColor", this, "SplitNameColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        trkSegmentTimerRatio.DataBindings.Add("Value", this, "SegmentTimerSizeRatio", false, DataSourceUpdateMode.OnPropertyChanged);
+        lblSegmentLabelsFont.DataBindings.Add("Text", this, "SegmentLabelsFontString", false, DataSourceUpdateMode.OnPropertyChanged);
+        lblSegmentTimesFont.DataBindings.Add("Text", this, "SegmentTimesFontString", false, DataSourceUpdateMode.OnPropertyChanged);
+        lblSplitNameFont.DataBindings.Add("Text", this, "SplitNameFontString", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkDisplayIcon.DataBindings.Add("Checked", this, "DisplayIcon", false, DataSourceUpdateMode.OnPropertyChanged);
+        trkIconSize.DataBindings.Add("Value", this, "IconSize", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbComparison.DataBindings.Add("SelectedItem", this, "Comparison", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbComparison2.DataBindings.Add("SelectedItem", this, "Comparison2", false, DataSourceUpdateMode.OnPropertyChanged);
+        chkHideComparison.DataBindings.Add("Checked", this, "HideComparison", false, DataSourceUpdateMode.OnPropertyChanged);
+        trkDecimalsSize.DataBindings.Add("Value", this, "DecimalsSize", false, DataSourceUpdateMode.OnPropertyChanged);
+        trkSegmentDecimalsSize.DataBindings.Add("Value", this, "SegmentTimerDecimalsSize", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbDigitsFormat.DataBindings.Add("SelectedItem", this, "DigitsFormat", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbAccuracy.DataBindings.Add("SelectedItem", this, "Accuracy", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbSegmentDigitsFormat.DataBindings.Add("SelectedItem", this, "SegmentDigitsFormat", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbSegmentAccuracy.DataBindings.Add("SelectedItem", this, "SegmentAccuracy", false, DataSourceUpdateMode.OnPropertyChanged);
+        cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
+    }
+
+    void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        TimingMethod = cmbTimingMethod.SelectedItem.ToString();
+    }
+
+    void cmbSegmentDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        SegmentDigitsFormat = cmbSegmentDigitsFormat.SelectedItem.ToString();
+    }
+
+    void cmbSegmentAccuracy_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        SegmentAccuracy = cmbSegmentAccuracy.SelectedItem.ToString();
+    }
+
+    void cmbDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        DigitsFormat = cmbDigitsFormat.SelectedItem.ToString();
+    }
+
+    void cmbAccuracy_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        Accuracy = cmbAccuracy.SelectedItem.ToString();
+    }
+
+    void chkSplitName_CheckedChanged(object sender, EventArgs e)
+    {
+        label9.Enabled = label10.Enabled = lblSplitNameFont.Enabled = btnSplitNameColor.Enabled
+            = btnSplitNameFont.Enabled = chkSplitName.Checked;
+
+    }
+
+    void chkDisplayIcon_CheckedChanged(object sender, EventArgs e)
+    {
+        label7.Enabled = trkIconSize.Enabled = chkDisplayIcon.Checked;
+    }
+
+    void chkOverrideTimerColors_CheckedChanged(object sender, EventArgs e)
+    {
+        label1.Enabled = btnTimerColor.Enabled = chkOverrideTimerColors.Checked;
+    }
+
+    void chkHideComparison_CheckedChanged(object sender, EventArgs e)
+    {
+        cmbComparison2.Enabled = label13.Enabled = !chkHideComparison.Checked;
+    }
+
+    void cmbComparison2_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        Comparison2 = cmbComparison2.SelectedItem.ToString();
+    }
+
+    void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        Comparison = cmbComparison.SelectedItem.ToString();
+    }
+
+    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var selectedText = cmbGradientType.SelectedItem.ToString();
+        btnColor1.Visible = selectedText != "Plain" && !selectedText.Contains("Delta");
+        btnColor2.Visible = !selectedText.Contains("Delta");
+        btnColor2.DataBindings.Clear();
+        btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
+        GradientString = cmbGradientType.SelectedItem.ToString();
+    }
+
+    void rdoSegmentTimesHundredths_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateAccuracySegmentTimes();
+    }
+
+    void rdoSegmentTimesTenths_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateAccuracySegmentTimes();
+    }
+
+    void rdoSegmentTimesSeconds_CheckedChanged(object sender, EventArgs e)
+    {
+        UpdateAccuracySegmentTimes();
+    }
+
+    void UpdateAccuracySegmentTimes()
+    {
+        if (rdoSegmentTimesSeconds.Checked)
+            SegmentTimesAccuracy = TimeAccuracy.Seconds;
+        else if (rdoSegmentTimesTenths.Checked)
+            SegmentTimesAccuracy = TimeAccuracy.Tenths;
+        else if (rdoSegmentTimesHundredths.Checked)
             SegmentTimesAccuracy = TimeAccuracy.Hundredths;
+        else
+            SegmentTimesAccuracy = TimeAccuracy.Milliseconds;
+        SegmentTimesFormatter.Accuracy = SegmentTimesAccuracy;
+    }
 
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+        Version version = SettingsHelper.ParseVersion(element["Version"]);
+
+        Height = SettingsHelper.ParseFloat(element["Height"]);
+        Width = SettingsHelper.ParseFloat(element["Width"]);
+        SegmentTimerSizeRatio = SettingsHelper.ParseFloat(element["SegmentTimerSizeRatio"]);
+        TimerShowGradient = SettingsHelper.ParseBool(element["TimerShowGradient"]);
+        SegmentTimerShowGradient = SettingsHelper.ParseBool(element["SegmentTimerShowGradient"]);
+        TimerColor = SettingsHelper.ParseColor(element["TimerColor"]);
+        SegmentTimerColor = SettingsHelper.ParseColor(element["SegmentTimerColor"]);
+        SegmentLabelsColor = SettingsHelper.ParseColor(element["SegmentLabelsColor"]);
+        SegmentTimesColor = SettingsHelper.ParseColor(element["SegmentTimesColor"]);
+        TimingMethod = SettingsHelper.ParseString(element["TimingMethod"], "Current Timing Method");
+        DecimalsSize = SettingsHelper.ParseFloat(element["DecimalsSize"], 35f);
+        SegmentTimerDecimalsSize = SettingsHelper.ParseFloat(element["SegmentTimerDecimalsSize"], 35f);
+        DisplayIcon = SettingsHelper.ParseBool(element["DisplayIcon"], false);
+        IconSize = SettingsHelper.ParseFloat(element["IconSize"], 40f);
+        ShowSplitName = SettingsHelper.ParseBool(element["ShowSplitName"], false);
+        SplitNameColor = SettingsHelper.ParseColor(element["SplitNameColor"], Color.FromArgb(255, 255, 255));
+        BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"], Color.Transparent);
+        BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"], Color.Transparent);
+        GradientString = SettingsHelper.ParseString(element["BackgroundGradient"], DeltasGradientType.Plain.ToString());
+        Comparison = SettingsHelper.ParseString(element["Comparison"], "Current Comparison");
+        Comparison2 = SettingsHelper.ParseString(element["Comparison2"], "Best Segments");
+        HideComparison = SettingsHelper.ParseBool(element["HideComparison"], false);
+        SegmentTimesAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["SegmentTimesAccuracy"]);
+
+        if (version >= new Version(1, 3))
+        {
+            OverrideTimerColors = SettingsHelper.ParseBool(element["OverrideTimerColors"]);
+            SegmentLabelsFont = SettingsHelper.GetFontFromElement(element["SegmentLabelsFont"]);
+            SegmentTimesFont = SettingsHelper.GetFontFromElement(element["SegmentTimesFont"]);
+            SplitNameFont = SettingsHelper.GetFontFromElement(element["SplitNameFont"]);
+        }
+        else
+        {
+            OverrideTimerColors = !SettingsHelper.ParseBool(element["TimerUseSplitColors"]);
             SegmentLabelsFont = new Font("Segoe UI", 13, FontStyle.Regular, GraphicsUnit.Pixel);
             SegmentTimesFont = new Font("Segoe UI", 13, FontStyle.Bold, GraphicsUnit.Pixel);
             SplitNameFont = new Font("Segoe UI", 15, FontStyle.Regular, GraphicsUnit.Pixel);
-
-            BackgroundColor = Color.Transparent;
-            BackgroundColor2 = Color.Transparent;
-            BackgroundGradient = DeltasGradientType.Plain;
-
-            IconSize = 40f;
-            DisplayIcon = false;
-
-            DecimalsSize = 35f;
-            SegmentTimerDecimalsSize = 35f;
-
-            Comparison = "Current Comparison";
-            Comparison2 = "Best Segments";
-            HideComparison = false;
-            TimingMethod = "Current Timing Method";
-
-            chkShowGradientSegmentTimer.DataBindings.Add("Checked", this, "SegmentTimerShowGradient", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkShowGradientTimer.DataBindings.Add("Checked", this, "TimerShowGradient", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkOverrideTimerColors.DataBindings.Add("Checked", this, "OverrideTimerColors", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkSplitName.DataBindings.Add("Checked", this, "ShowSplitName", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnTimerColor.DataBindings.Add("BackColor", this, "TimerColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnSegmentTimerColor.DataBindings.Add("BackColor", this, "SegmentTimerColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnSegmentLabelsColor.DataBindings.Add("BackColor", this, "SegmentLabelsColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnSegmentTimesColor.DataBindings.Add("BackColor", this, "SegmentTimesColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnSplitNameColor.DataBindings.Add("BackColor", this, "SplitNameColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            trkSegmentTimerRatio.DataBindings.Add("Value", this, "SegmentTimerSizeRatio", false, DataSourceUpdateMode.OnPropertyChanged);
-            lblSegmentLabelsFont.DataBindings.Add("Text", this, "SegmentLabelsFontString", false, DataSourceUpdateMode.OnPropertyChanged);
-            lblSegmentTimesFont.DataBindings.Add("Text", this, "SegmentTimesFontString", false, DataSourceUpdateMode.OnPropertyChanged);
-            lblSplitNameFont.DataBindings.Add("Text", this, "SplitNameFontString", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkDisplayIcon.DataBindings.Add("Checked", this, "DisplayIcon", false, DataSourceUpdateMode.OnPropertyChanged);
-            trkIconSize.DataBindings.Add("Value", this, "IconSize", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbGradientType.DataBindings.Add("SelectedItem", this, "GradientString", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor1.DataBindings.Add("BackColor", this, "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            btnColor2.DataBindings.Add("BackColor", this, "BackgroundColor2", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbComparison.DataBindings.Add("SelectedItem", this, "Comparison", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbComparison2.DataBindings.Add("SelectedItem", this, "Comparison2", false, DataSourceUpdateMode.OnPropertyChanged);
-            chkHideComparison.DataBindings.Add("Checked", this, "HideComparison", false, DataSourceUpdateMode.OnPropertyChanged);
-            trkDecimalsSize.DataBindings.Add("Value", this, "DecimalsSize", false, DataSourceUpdateMode.OnPropertyChanged);
-            trkSegmentDecimalsSize.DataBindings.Add("Value", this, "SegmentTimerDecimalsSize", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbDigitsFormat.DataBindings.Add("SelectedItem", this, "DigitsFormat", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbAccuracy.DataBindings.Add("SelectedItem", this, "Accuracy", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbSegmentDigitsFormat.DataBindings.Add("SelectedItem", this, "SegmentDigitsFormat", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbSegmentAccuracy.DataBindings.Add("SelectedItem", this, "SegmentAccuracy", false, DataSourceUpdateMode.OnPropertyChanged);
-            cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
         }
 
-        void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
+        if (version >= new Version(1, 5))
         {
-            TimingMethod = cmbTimingMethod.SelectedItem.ToString();
+            timerFormat = element["TimerFormat"].InnerText;
+            segmentTimerFormat = element["SegmentTimerFormat"].InnerText;
         }
-
-        void cmbSegmentDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
+        else
         {
-            SegmentDigitsFormat = cmbSegmentDigitsFormat.SelectedItem.ToString();
-        }
-
-        void cmbSegmentAccuracy_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            SegmentAccuracy = cmbSegmentAccuracy.SelectedItem.ToString();
-        }
-
-        void cmbDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            DigitsFormat = cmbDigitsFormat.SelectedItem.ToString();
-        }
-
-        void cmbAccuracy_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            Accuracy = cmbAccuracy.SelectedItem.ToString();
-        }
-
-        void chkSplitName_CheckedChanged(object sender, EventArgs e)
-        {
-            label9.Enabled = label10.Enabled = lblSplitNameFont.Enabled = btnSplitNameColor.Enabled
-                = btnSplitNameFont.Enabled = chkSplitName.Checked;
-
-        }
-
-        void chkDisplayIcon_CheckedChanged(object sender, EventArgs e)
-        {
-            label7.Enabled = trkIconSize.Enabled = chkDisplayIcon.Checked;
-        }
-
-        void chkOverrideTimerColors_CheckedChanged(object sender, EventArgs e)
-        {
-            label1.Enabled = btnTimerColor.Enabled = chkOverrideTimerColors.Checked;
-        }
-
-        void chkHideComparison_CheckedChanged(object sender, EventArgs e)
-        {
-            cmbComparison2.Enabled = label13.Enabled = !chkHideComparison.Checked;
-        }
-
-        void cmbComparison2_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            Comparison2 = cmbComparison2.SelectedItem.ToString();
-        }
-
-        void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            Comparison = cmbComparison.SelectedItem.ToString();
-        }
-
-        void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            var selectedText = cmbGradientType.SelectedItem.ToString();
-            btnColor1.Visible = selectedText != "Plain" && !selectedText.Contains("Delta");
-            btnColor2.Visible = !selectedText.Contains("Delta");
-            btnColor2.DataBindings.Clear();
-            btnColor2.DataBindings.Add("BackColor", this, btnColor1.Visible ? "BackgroundColor2" : "BackgroundColor", false, DataSourceUpdateMode.OnPropertyChanged);
-            GradientString = cmbGradientType.SelectedItem.ToString();
-        }
-
-        void rdoSegmentTimesHundredths_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateAccuracySegmentTimes();
-        }
-
-        void rdoSegmentTimesTenths_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateAccuracySegmentTimes();
-        }
-
-        void rdoSegmentTimesSeconds_CheckedChanged(object sender, EventArgs e)
-        {
-            UpdateAccuracySegmentTimes();
-        }
-
-        void UpdateAccuracySegmentTimes()
-        {
-            if (rdoSegmentTimesSeconds.Checked)
-                SegmentTimesAccuracy = TimeAccuracy.Seconds;
-            else if (rdoSegmentTimesTenths.Checked)
-                SegmentTimesAccuracy = TimeAccuracy.Tenths;
-            else if (rdoSegmentTimesHundredths.Checked)
-                SegmentTimesAccuracy = TimeAccuracy.Hundredths;
-            else
-                SegmentTimesAccuracy = TimeAccuracy.Milliseconds;
-            SegmentTimesFormatter.Accuracy = SegmentTimesAccuracy;
-        }
-
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
-            Version version = SettingsHelper.ParseVersion(element["Version"]);
-
-            Height = SettingsHelper.ParseFloat(element["Height"]);
-            Width = SettingsHelper.ParseFloat(element["Width"]);
-            SegmentTimerSizeRatio = SettingsHelper.ParseFloat(element["SegmentTimerSizeRatio"]);
-            TimerShowGradient = SettingsHelper.ParseBool(element["TimerShowGradient"]);
-            SegmentTimerShowGradient = SettingsHelper.ParseBool(element["SegmentTimerShowGradient"]);
-            TimerColor = SettingsHelper.ParseColor(element["TimerColor"]);
-            SegmentTimerColor = SettingsHelper.ParseColor(element["SegmentTimerColor"]);
-            SegmentLabelsColor = SettingsHelper.ParseColor(element["SegmentLabelsColor"]);
-            SegmentTimesColor = SettingsHelper.ParseColor(element["SegmentTimesColor"]);
-            TimingMethod = SettingsHelper.ParseString(element["TimingMethod"], "Current Timing Method");
-            DecimalsSize = SettingsHelper.ParseFloat(element["DecimalsSize"], 35f);
-            SegmentTimerDecimalsSize = SettingsHelper.ParseFloat(element["SegmentTimerDecimalsSize"], 35f);
-            DisplayIcon = SettingsHelper.ParseBool(element["DisplayIcon"], false);
-            IconSize = SettingsHelper.ParseFloat(element["IconSize"], 40f);
-            ShowSplitName = SettingsHelper.ParseBool(element["ShowSplitName"], false);
-            SplitNameColor = SettingsHelper.ParseColor(element["SplitNameColor"], Color.FromArgb(255, 255, 255));
-            BackgroundColor = SettingsHelper.ParseColor(element["BackgroundColor"], Color.Transparent);
-            BackgroundColor2 = SettingsHelper.ParseColor(element["BackgroundColor2"], Color.Transparent);
-            GradientString = SettingsHelper.ParseString(element["BackgroundGradient"], DeltasGradientType.Plain.ToString());
-            Comparison = SettingsHelper.ParseString(element["Comparison"], "Current Comparison");
-            Comparison2 = SettingsHelper.ParseString(element["Comparison2"], "Best Segments");
-            HideComparison = SettingsHelper.ParseBool(element["HideComparison"], false);
-            SegmentTimesAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["SegmentTimesAccuracy"]);
-
-            if (version >= new Version(1, 3))
+            DigitsFormat = "1";
+            SegmentDigitsFormat = "1";
+            var timerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["TimerAccuracy"]);
+            switch (timerAccuracy)
             {
-                OverrideTimerColors = SettingsHelper.ParseBool(element["OverrideTimerColors"]);
-                SegmentLabelsFont = SettingsHelper.GetFontFromElement(element["SegmentLabelsFont"]);
-                SegmentTimesFont = SettingsHelper.GetFontFromElement(element["SegmentTimesFont"]);
-                SplitNameFont = SettingsHelper.GetFontFromElement(element["SplitNameFont"]);
-            }
-            else
-            {
-                OverrideTimerColors = !SettingsHelper.ParseBool(element["TimerUseSplitColors"]);
-                SegmentLabelsFont = new Font("Segoe UI", 13, FontStyle.Regular, GraphicsUnit.Pixel);
-                SegmentTimesFont = new Font("Segoe UI", 13, FontStyle.Bold, GraphicsUnit.Pixel);
-                SplitNameFont = new Font("Segoe UI", 15, FontStyle.Regular, GraphicsUnit.Pixel);
+                case TimeAccuracy.Seconds: Accuracy = ""; break;
+                case TimeAccuracy.Tenths: Accuracy = ".2"; break;
+                case TimeAccuracy.Hundredths: Accuracy = ".23"; break;
+                case TimeAccuracy.Milliseconds: Accuracy = ".234"; break;
+                default: Accuracy = ".23"; break;
             }
 
-            if (version >= new Version(1, 5))
+            var segmentTimerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["SegmentTimerAccuracy"]);
+            switch (segmentTimerAccuracy)
             {
-                timerFormat = element["TimerFormat"].InnerText;
-                segmentTimerFormat = element["SegmentTimerFormat"].InnerText;
-            }
-            else
-            {
-                DigitsFormat = "1";
-                SegmentDigitsFormat = "1";
-                var timerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["TimerAccuracy"]);
-                switch (timerAccuracy)
-                {
-                    case TimeAccuracy.Seconds: Accuracy = ""; break;
-                    case TimeAccuracy.Tenths: Accuracy = ".2"; break;
-                    case TimeAccuracy.Hundredths: Accuracy = ".23"; break;
-                    case TimeAccuracy.Milliseconds: Accuracy = ".234"; break;
-                    default: Accuracy = ".23"; break;
-                }
-
-                var segmentTimerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["SegmentTimerAccuracy"]);
-                switch (segmentTimerAccuracy)
-                {
-                    case TimeAccuracy.Seconds: SegmentAccuracy = ""; break;
-                    case TimeAccuracy.Tenths: SegmentAccuracy = ".2"; break;
-                    case TimeAccuracy.Hundredths: SegmentAccuracy = ".23"; break;
-                    case TimeAccuracy.Milliseconds: SegmentAccuracy = ".234"; break;
-                    default: SegmentAccuracy = ".23"; break;
-                }
+                case TimeAccuracy.Seconds: SegmentAccuracy = ""; break;
+                case TimeAccuracy.Tenths: SegmentAccuracy = ".2"; break;
+                case TimeAccuracy.Hundredths: SegmentAccuracy = ".23"; break;
+                case TimeAccuracy.Milliseconds: SegmentAccuracy = ".234"; break;
+                default: SegmentAccuracy = ".23"; break;
             }
         }
+    }
 
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
-        }
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
 
-        public int GetSettingsHashCode()
-        {
-            return CreateSettingsNode(null, null);
-        }
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
 
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.5") ^
-            SettingsHelper.CreateSetting(document, parent, "Height", Height) ^
-            SettingsHelper.CreateSetting(document, parent, "Width", Width) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimerSizeRatio", SegmentTimerSizeRatio) ^
-            SettingsHelper.CreateSetting(document, parent, "TimerShowGradient", TimerShowGradient) ^
-            SettingsHelper.CreateSetting(document, parent, "OverrideTimerColors", OverrideTimerColors) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimerShowGradient", SegmentTimerShowGradient) ^
-            SettingsHelper.CreateSetting(document, parent, "TimerFormat", timerFormat) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimerFormat", segmentTimerFormat) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimesAccuracy", SegmentTimesAccuracy) ^
-            SettingsHelper.CreateSetting(document, parent, "TimerColor", TimerColor) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimerColor", SegmentTimerColor) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentLabelsColor", SegmentLabelsColor) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimesColor", SegmentTimesColor) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentLabelsFont", SegmentLabelsFont) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimesFont", SegmentTimesFont) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitNameFont", SplitNameFont) ^
-            SettingsHelper.CreateSetting(document, parent, "DisplayIcon", DisplayIcon) ^
-            SettingsHelper.CreateSetting(document, parent, "IconSize", IconSize) ^
-            SettingsHelper.CreateSetting(document, parent, "ShowSplitName", ShowSplitName) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitNameColor", SplitNameColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
-            SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
-            SettingsHelper.CreateSetting(document, parent, "Comparison", Comparison) ^
-            SettingsHelper.CreateSetting(document, parent, "Comparison2", Comparison2) ^
-            SettingsHelper.CreateSetting(document, parent, "HideComparison", HideComparison) ^
-            SettingsHelper.CreateSetting(document, parent, "TimingMethod", TimingMethod) ^
-            SettingsHelper.CreateSetting(document, parent, "DecimalsSize", DecimalsSize) ^
-            SettingsHelper.CreateSetting(document, parent, "SegmentTimerDecimalsSize", SegmentTimerDecimalsSize);
-        }
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.5") ^
+        SettingsHelper.CreateSetting(document, parent, "Height", Height) ^
+        SettingsHelper.CreateSetting(document, parent, "Width", Width) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimerSizeRatio", SegmentTimerSizeRatio) ^
+        SettingsHelper.CreateSetting(document, parent, "TimerShowGradient", TimerShowGradient) ^
+        SettingsHelper.CreateSetting(document, parent, "OverrideTimerColors", OverrideTimerColors) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimerShowGradient", SegmentTimerShowGradient) ^
+        SettingsHelper.CreateSetting(document, parent, "TimerFormat", timerFormat) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimerFormat", segmentTimerFormat) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimesAccuracy", SegmentTimesAccuracy) ^
+        SettingsHelper.CreateSetting(document, parent, "TimerColor", TimerColor) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimerColor", SegmentTimerColor) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentLabelsColor", SegmentLabelsColor) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimesColor", SegmentTimesColor) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentLabelsFont", SegmentLabelsFont) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimesFont", SegmentTimesFont) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitNameFont", SplitNameFont) ^
+        SettingsHelper.CreateSetting(document, parent, "DisplayIcon", DisplayIcon) ^
+        SettingsHelper.CreateSetting(document, parent, "IconSize", IconSize) ^
+        SettingsHelper.CreateSetting(document, parent, "ShowSplitName", ShowSplitName) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitNameColor", SplitNameColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor", BackgroundColor) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundColor2", BackgroundColor2) ^
+        SettingsHelper.CreateSetting(document, parent, "BackgroundGradient", BackgroundGradient) ^
+        SettingsHelper.CreateSetting(document, parent, "Comparison", Comparison) ^
+        SettingsHelper.CreateSetting(document, parent, "Comparison2", Comparison2) ^
+        SettingsHelper.CreateSetting(document, parent, "HideComparison", HideComparison) ^
+        SettingsHelper.CreateSetting(document, parent, "TimingMethod", TimingMethod) ^
+        SettingsHelper.CreateSetting(document, parent, "DecimalsSize", DecimalsSize) ^
+        SettingsHelper.CreateSetting(document, parent, "SegmentTimerDecimalsSize", SegmentTimerDecimalsSize);
+    }
 
-        private void ColorButtonClick(object sender, EventArgs e)
-        {
-            SettingsHelper.ColorButtonClick((Button)sender, this);
-        }
+    private void ColorButtonClick(object sender, EventArgs e)
+    {
+        SettingsHelper.ColorButtonClick((Button)sender, this);
+    }
 
-        void DetailedTimerSettings_Load(object sender, EventArgs e)
-        {
-            chkHideComparison_CheckedChanged(null, null);
-            chkOverrideTimerColors_CheckedChanged(null, null);
-            chkDisplayIcon_CheckedChanged(null, null);
-            chkSplitName_CheckedChanged(null, null);
-            cmbComparison.Items.Clear();
-            cmbComparison.Items.Add("Current Comparison");
-            cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
-            if (!cmbComparison.Items.Contains(Comparison))
-                cmbComparison.Items.Add(Comparison);
-            cmbComparison2.Items.Clear();
-            cmbComparison2.Items.Add("Current Comparison");
-            cmbComparison2.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
-            if (!cmbComparison2.Items.Contains(Comparison2))
-                cmbComparison2.Items.Add(Comparison2);
-            rdoSegmentTimesMilliseconds.Checked = SegmentTimesAccuracy == TimeAccuracy.Milliseconds;
-            rdoSegmentTimesHundredths.Checked = SegmentTimesAccuracy == TimeAccuracy.Hundredths;
-            rdoSegmentTimesTenths.Checked = SegmentTimesAccuracy == TimeAccuracy.Tenths;
-            rdoSegmentTimesSeconds.Checked = SegmentTimesAccuracy == TimeAccuracy.Seconds;
+    void DetailedTimerSettings_Load(object sender, EventArgs e)
+    {
+        chkHideComparison_CheckedChanged(null, null);
+        chkOverrideTimerColors_CheckedChanged(null, null);
+        chkDisplayIcon_CheckedChanged(null, null);
+        chkSplitName_CheckedChanged(null, null);
+        cmbComparison.Items.Clear();
+        cmbComparison.Items.Add("Current Comparison");
+        cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
+        if (!cmbComparison.Items.Contains(Comparison))
+            cmbComparison.Items.Add(Comparison);
+        cmbComparison2.Items.Clear();
+        cmbComparison2.Items.Add("Current Comparison");
+        cmbComparison2.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
+        if (!cmbComparison2.Items.Contains(Comparison2))
+            cmbComparison2.Items.Add(Comparison2);
+        rdoSegmentTimesMilliseconds.Checked = SegmentTimesAccuracy == TimeAccuracy.Milliseconds;
+        rdoSegmentTimesHundredths.Checked = SegmentTimesAccuracy == TimeAccuracy.Hundredths;
+        rdoSegmentTimesTenths.Checked = SegmentTimesAccuracy == TimeAccuracy.Tenths;
+        rdoSegmentTimesSeconds.Checked = SegmentTimesAccuracy == TimeAccuracy.Seconds;
 
-            if (Mode == LayoutMode.Horizontal)
-            {
-                trkSize.DataBindings.Clear();
-                trkSize.Minimum = 50;
-                trkSize.Maximum = 500;
-                trkSize.DataBindings.Add("Value", this, "Width", false, DataSourceUpdateMode.OnPropertyChanged);
-                lblSize.Text = "Width:";
-            }
-            else
-            {
-                trkSize.DataBindings.Clear();
-                trkSize.Minimum = 20;
-                trkSize.Maximum = 150;
-                trkSize.DataBindings.Add("Value", this, "Height", false, DataSourceUpdateMode.OnPropertyChanged);
-                lblSize.Text = "Height:";
-            }
+        if (Mode == LayoutMode.Horizontal)
+        {
+            trkSize.DataBindings.Clear();
+            trkSize.Minimum = 50;
+            trkSize.Maximum = 500;
+            trkSize.DataBindings.Add("Value", this, "Width", false, DataSourceUpdateMode.OnPropertyChanged);
+            lblSize.Text = "Width:";
         }
+        else
+        {
+            trkSize.DataBindings.Clear();
+            trkSize.Minimum = 20;
+            trkSize.Maximum = 150;
+            trkSize.DataBindings.Add("Value", this, "Height", false, DataSourceUpdateMode.OnPropertyChanged);
+            lblSize.Text = "Height:";
+        }
+    }
 
-        private void btnSegmentLabelsFont_Click(object sender, EventArgs e)
-        {
-            var dialog = SettingsHelper.GetFontDialog(SegmentLabelsFont, 7, 26);
-            dialog.FontChanged += (s, ev) => SegmentLabelsFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
-            dialog.ShowDialog(this);
-            lblSegmentLabelsFont.Text = SegmentLabelsFontString;
-        }
+    private void btnSegmentLabelsFont_Click(object sender, EventArgs e)
+    {
+        var dialog = SettingsHelper.GetFontDialog(SegmentLabelsFont, 7, 26);
+        dialog.FontChanged += (s, ev) => SegmentLabelsFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+        dialog.ShowDialog(this);
+        lblSegmentLabelsFont.Text = SegmentLabelsFontString;
+    }
 
-        private void btnSegmentTimesFont_Click(object sender, EventArgs e)
-        {
-            var dialog = SettingsHelper.GetFontDialog(SegmentTimesFont, 7, 26);
-            dialog.FontChanged += (s, ev) => SegmentTimesFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
-            dialog.ShowDialog(this);
-            lblSegmentTimesFont.Text = SegmentTimesFontString;
-        }
-        private void btnSplitNameFont_Click(object sender, EventArgs e)
-        {
-            var dialog = SettingsHelper.GetFontDialog(SplitNameFont, 7, 26);
-            dialog.FontChanged += (s, ev) => SplitNameFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
-            dialog.ShowDialog(this);
-            lblSplitNameFont.Text = SplitNameFontString;
-        }
+    private void btnSegmentTimesFont_Click(object sender, EventArgs e)
+    {
+        var dialog = SettingsHelper.GetFontDialog(SegmentTimesFont, 7, 26);
+        dialog.FontChanged += (s, ev) => SegmentTimesFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+        dialog.ShowDialog(this);
+        lblSegmentTimesFont.Text = SegmentTimesFontString;
+    }
+    private void btnSplitNameFont_Click(object sender, EventArgs e)
+    {
+        var dialog = SettingsHelper.GetFontDialog(SplitNameFont, 7, 26);
+        dialog.FontChanged += (s, ev) => SplitNameFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
+        dialog.ShowDialog(this);
+        lblSplitNameFont.Text = SplitNameFontString;
     }
 }

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -40,15 +40,12 @@ public partial class DetailedTimerSettings : UserControl
     public DeltasGradientType BackgroundGradient { get; set; }
     public string GradientString
     {
-        get { return TimerSettings.GetBackgroundTypeString(BackgroundGradient); }
-        set { BackgroundGradient = (DeltasGradientType)Enum.Parse(typeof(DeltasGradientType), value.Replace(" ", "")); }
+        get => TimerSettings.GetBackgroundTypeString(BackgroundGradient);
+        set => BackgroundGradient = (DeltasGradientType)Enum.Parse(typeof(DeltasGradientType), value.Replace(" ", ""));
     }
     private string timerFormat
     {
-        get
-        {
-            return DigitsFormat + Accuracy;
-        }
+        get => DigitsFormat + Accuracy;
         set
         {
             var decimalIndex = value.IndexOf('.');
@@ -68,10 +65,7 @@ public partial class DetailedTimerSettings : UserControl
     public string Accuracy { get; set; }
     private string segmentTimerFormat
     {
-        get
-        {
-            return SegmentDigitsFormat + SegmentAccuracy;
-        }
+        get => SegmentDigitsFormat + SegmentAccuracy;
         set
         {
             var decimalIndex = value.IndexOf('.');

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -262,13 +262,22 @@ public partial class DetailedTimerSettings : UserControl
     private void UpdateAccuracySegmentTimes()
     {
         if (rdoSegmentTimesSeconds.Checked)
+        {
             SegmentTimesAccuracy = TimeAccuracy.Seconds;
+        }
         else if (rdoSegmentTimesTenths.Checked)
+        {
             SegmentTimesAccuracy = TimeAccuracy.Tenths;
+        }
         else if (rdoSegmentTimesHundredths.Checked)
+        {
             SegmentTimesAccuracy = TimeAccuracy.Hundredths;
+        }
         else
+        {
             SegmentTimesAccuracy = TimeAccuracy.Milliseconds;
+        }
+
         SegmentTimesFormatter.Accuracy = SegmentTimesAccuracy;
     }
 
@@ -408,12 +417,18 @@ public partial class DetailedTimerSettings : UserControl
         cmbComparison.Items.Add("Current Comparison");
         cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
         if (!cmbComparison.Items.Contains(Comparison))
+        {
             cmbComparison.Items.Add(Comparison);
+        }
+
         cmbComparison2.Items.Clear();
         cmbComparison2.Items.Add("Current Comparison");
         cmbComparison2.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
         if (!cmbComparison2.Items.Contains(Comparison2))
+        {
             cmbComparison2.Items.Add(Comparison2);
+        }
+
         rdoSegmentTimesMilliseconds.Checked = SegmentTimesAccuracy == TimeAccuracy.Milliseconds;
         rdoSegmentTimesHundredths.Checked = SegmentTimesAccuracy == TimeAccuracy.Hundredths;
         rdoSegmentTimesTenths.Checked = SegmentTimesAccuracy == TimeAccuracy.Tenths;

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -335,24 +335,23 @@ public partial class DetailedTimerSettings : UserControl
             DigitsFormat = "1";
             SegmentDigitsFormat = "1";
             TimeAccuracy timerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["TimerAccuracy"]);
-            switch (timerAccuracy)
+            Accuracy = timerAccuracy switch
             {
-                case TimeAccuracy.Seconds: Accuracy = ""; break;
-                case TimeAccuracy.Tenths: Accuracy = ".2"; break;
-                case TimeAccuracy.Hundredths: Accuracy = ".23"; break;
-                case TimeAccuracy.Milliseconds: Accuracy = ".234"; break;
-                default: Accuracy = ".23"; break;
-            }
-
+                TimeAccuracy.Seconds => "",
+                TimeAccuracy.Tenths => ".2",
+                TimeAccuracy.Hundredths => ".23",
+                TimeAccuracy.Milliseconds => ".234",
+                _ => ".23",
+            };
             TimeAccuracy segmentTimerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["SegmentTimerAccuracy"]);
-            switch (segmentTimerAccuracy)
+            SegmentAccuracy = segmentTimerAccuracy switch
             {
-                case TimeAccuracy.Seconds: SegmentAccuracy = ""; break;
-                case TimeAccuracy.Tenths: SegmentAccuracy = ".2"; break;
-                case TimeAccuracy.Hundredths: SegmentAccuracy = ".23"; break;
-                case TimeAccuracy.Milliseconds: SegmentAccuracy = ".234"; break;
-                default: SegmentAccuracy = ".23"; break;
-            }
+                TimeAccuracy.Seconds => "",
+                TimeAccuracy.Tenths => ".2",
+                TimeAccuracy.Hundredths => ".23",
+                TimeAccuracy.Milliseconds => ".234",
+                _ => ".23",
+            };
         }
     }
 

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -12,8 +12,8 @@ namespace LiveSplit.UI.Components;
 
 public partial class DetailedTimerSettings : UserControl
 {
-    public float Height { get; set; }
-    public float Width { get; set; }
+    public new float Height { get; set; }
+    public new float Width { get; set; }
     public float SegmentTimerSizeRatio { get; set; }
     public LiveSplitState CurrentState { get; set; }
 

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -56,8 +56,8 @@ public partial class DetailedTimerSettings : UserControl
             }
             else
             {
-                DigitsFormat = value.Substring(0, decimalIndex);
-                Accuracy = value.Substring(decimalIndex);
+                DigitsFormat = value[..decimalIndex];
+                Accuracy = value[decimalIndex..];
             }
         }
     }
@@ -76,8 +76,8 @@ public partial class DetailedTimerSettings : UserControl
             }
             else
             {
-                SegmentDigitsFormat = value.Substring(0, decimalIndex);
-                SegmentAccuracy = value.Substring(decimalIndex);
+                SegmentDigitsFormat = value[..decimalIndex];
+                SegmentAccuracy = value[decimalIndex..];
             }
         }
     }

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -415,7 +415,7 @@ public partial class DetailedTimerSettings : UserControl
         chkSplitName_CheckedChanged(null, null);
         cmbComparison.Items.Clear();
         cmbComparison.Items.Add("Current Comparison");
-        cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
+        cmbComparison.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x is not BestSplitTimesComparisonGenerator.ComparisonName and not NoneComparisonGenerator.ComparisonName).ToArray());
         if (!cmbComparison.Items.Contains(Comparison))
         {
             cmbComparison.Items.Add(Comparison);
@@ -423,7 +423,7 @@ public partial class DetailedTimerSettings : UserControl
 
         cmbComparison2.Items.Clear();
         cmbComparison2.Items.Add("Current Comparison");
-        cmbComparison2.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x != BestSplitTimesComparisonGenerator.ComparisonName && x != NoneComparisonGenerator.ComparisonName).ToArray());
+        cmbComparison2.Items.AddRange(CurrentState.Run.Comparisons.Where(x => x is not BestSplitTimesComparisonGenerator.ComparisonName and not NoneComparisonGenerator.ComparisonName).ToArray());
         if (!cmbComparison2.Items.Contains(Comparison2))
         {
             cmbComparison2.Items.Add(Comparison2);

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -183,64 +183,64 @@ public partial class DetailedTimerSettings : UserControl
         cmbTimingMethod.DataBindings.Add("SelectedItem", this, "TimingMethod", false, DataSourceUpdateMode.OnPropertyChanged);
     }
 
-    void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbTimingMethod_SelectedIndexChanged(object sender, EventArgs e)
     {
         TimingMethod = cmbTimingMethod.SelectedItem.ToString();
     }
 
-    void cmbSegmentDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbSegmentDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
     {
         SegmentDigitsFormat = cmbSegmentDigitsFormat.SelectedItem.ToString();
     }
 
-    void cmbSegmentAccuracy_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbSegmentAccuracy_SelectedIndexChanged(object sender, EventArgs e)
     {
         SegmentAccuracy = cmbSegmentAccuracy.SelectedItem.ToString();
     }
 
-    void cmbDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbDigitsFormat_SelectedIndexChanged(object sender, EventArgs e)
     {
         DigitsFormat = cmbDigitsFormat.SelectedItem.ToString();
     }
 
-    void cmbAccuracy_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbAccuracy_SelectedIndexChanged(object sender, EventArgs e)
     {
         Accuracy = cmbAccuracy.SelectedItem.ToString();
     }
 
-    void chkSplitName_CheckedChanged(object sender, EventArgs e)
+    private void chkSplitName_CheckedChanged(object sender, EventArgs e)
     {
         label9.Enabled = label10.Enabled = lblSplitNameFont.Enabled = btnSplitNameColor.Enabled
             = btnSplitNameFont.Enabled = chkSplitName.Checked;
 
     }
 
-    void chkDisplayIcon_CheckedChanged(object sender, EventArgs e)
+    private void chkDisplayIcon_CheckedChanged(object sender, EventArgs e)
     {
         label7.Enabled = trkIconSize.Enabled = chkDisplayIcon.Checked;
     }
 
-    void chkOverrideTimerColors_CheckedChanged(object sender, EventArgs e)
+    private void chkOverrideTimerColors_CheckedChanged(object sender, EventArgs e)
     {
         label1.Enabled = btnTimerColor.Enabled = chkOverrideTimerColors.Checked;
     }
 
-    void chkHideComparison_CheckedChanged(object sender, EventArgs e)
+    private void chkHideComparison_CheckedChanged(object sender, EventArgs e)
     {
         cmbComparison2.Enabled = label13.Enabled = !chkHideComparison.Checked;
     }
 
-    void cmbComparison2_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbComparison2_SelectedIndexChanged(object sender, EventArgs e)
     {
         Comparison2 = cmbComparison2.SelectedItem.ToString();
     }
 
-    void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbComparison_SelectedIndexChanged(object sender, EventArgs e)
     {
         Comparison = cmbComparison.SelectedItem.ToString();
     }
 
-    void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
+    private void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
     {
         var selectedText = cmbGradientType.SelectedItem.ToString();
         btnColor1.Visible = selectedText != "Plain" && !selectedText.Contains("Delta");
@@ -250,22 +250,22 @@ public partial class DetailedTimerSettings : UserControl
         GradientString = cmbGradientType.SelectedItem.ToString();
     }
 
-    void rdoSegmentTimesHundredths_CheckedChanged(object sender, EventArgs e)
+    private void rdoSegmentTimesHundredths_CheckedChanged(object sender, EventArgs e)
     {
         UpdateAccuracySegmentTimes();
     }
 
-    void rdoSegmentTimesTenths_CheckedChanged(object sender, EventArgs e)
+    private void rdoSegmentTimesTenths_CheckedChanged(object sender, EventArgs e)
     {
         UpdateAccuracySegmentTimes();
     }
 
-    void rdoSegmentTimesSeconds_CheckedChanged(object sender, EventArgs e)
+    private void rdoSegmentTimesSeconds_CheckedChanged(object sender, EventArgs e)
     {
         UpdateAccuracySegmentTimes();
     }
 
-    void UpdateAccuracySegmentTimes()
+    private void UpdateAccuracySegmentTimes()
     {
         if (rdoSegmentTimesSeconds.Checked)
             SegmentTimesAccuracy = TimeAccuracy.Seconds;
@@ -404,7 +404,7 @@ public partial class DetailedTimerSettings : UserControl
         SettingsHelper.ColorButtonClick((Button)sender, this);
     }
 
-    void DetailedTimerSettings_Load(object sender, EventArgs e)
+    private void DetailedTimerSettings_Load(object sender, EventArgs e)
     {
         chkHideComparison_CheckedChanged(null, null);
         chkOverrideTimerColors_CheckedChanged(null, null);

--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -48,7 +48,7 @@ public partial class DetailedTimerSettings : UserControl
         get => DigitsFormat + Accuracy;
         set
         {
-            var decimalIndex = value.IndexOf('.');
+            int decimalIndex = value.IndexOf('.');
             if (decimalIndex < 0)
             {
                 DigitsFormat = value;
@@ -68,7 +68,7 @@ public partial class DetailedTimerSettings : UserControl
         get => SegmentDigitsFormat + SegmentAccuracy;
         set
         {
-            var decimalIndex = value.IndexOf('.');
+            int decimalIndex = value.IndexOf('.');
             if (decimalIndex < 0)
             {
                 SegmentDigitsFormat = value;
@@ -236,7 +236,7 @@ public partial class DetailedTimerSettings : UserControl
 
     private void cmbGradientType_SelectedIndexChanged(object sender, EventArgs e)
     {
-        var selectedText = cmbGradientType.SelectedItem.ToString();
+        string selectedText = cmbGradientType.SelectedItem.ToString();
         btnColor1.Visible = selectedText != "Plain" && !selectedText.Contains("Delta");
         btnColor2.Visible = !selectedText.Contains("Delta");
         btnColor2.DataBindings.Clear();
@@ -334,7 +334,7 @@ public partial class DetailedTimerSettings : UserControl
         {
             DigitsFormat = "1";
             SegmentDigitsFormat = "1";
-            var timerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["TimerAccuracy"]);
+            TimeAccuracy timerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["TimerAccuracy"]);
             switch (timerAccuracy)
             {
                 case TimeAccuracy.Seconds: Accuracy = ""; break;
@@ -344,7 +344,7 @@ public partial class DetailedTimerSettings : UserControl
                 default: Accuracy = ".23"; break;
             }
 
-            var segmentTimerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["SegmentTimerAccuracy"]);
+            TimeAccuracy segmentTimerAccuracy = SettingsHelper.ParseEnum<TimeAccuracy>(element["SegmentTimerAccuracy"]);
             switch (segmentTimerAccuracy)
             {
                 case TimeAccuracy.Seconds: SegmentAccuracy = ""; break;
@@ -358,7 +358,7 @@ public partial class DetailedTimerSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }
@@ -454,7 +454,7 @@ public partial class DetailedTimerSettings : UserControl
 
     private void btnSegmentLabelsFont_Click(object sender, EventArgs e)
     {
-        var dialog = SettingsHelper.GetFontDialog(SegmentLabelsFont, 7, 26);
+        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(SegmentLabelsFont, 7, 26);
         dialog.FontChanged += (s, ev) => SegmentLabelsFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
         dialog.ShowDialog(this);
         lblSegmentLabelsFont.Text = SegmentLabelsFontString;
@@ -462,14 +462,14 @@ public partial class DetailedTimerSettings : UserControl
 
     private void btnSegmentTimesFont_Click(object sender, EventArgs e)
     {
-        var dialog = SettingsHelper.GetFontDialog(SegmentTimesFont, 7, 26);
+        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(SegmentTimesFont, 7, 26);
         dialog.FontChanged += (s, ev) => SegmentTimesFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
         dialog.ShowDialog(this);
         lblSegmentTimesFont.Text = SegmentTimesFontString;
     }
     private void btnSplitNameFont_Click(object sender, EventArgs e)
     {
-        var dialog = SettingsHelper.GetFontDialog(SplitNameFont, 7, 26);
+        CustomFontDialog.FontDialog dialog = SettingsHelper.GetFontDialog(SplitNameFont, 7, 26);
         dialog.FontChanged += (s, ev) => SplitNameFont = ((CustomFontDialog.FontChangedEventArgs)ev).NewFont;
         dialog.ShowDialog(this);
         lblSplitNameFont.Text = SplitNameFontString;

--- a/src/LiveSplit.DetailedTimer/UI/Components/SegmentTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/SegmentTimer.cs
@@ -9,7 +9,7 @@ public class SegmentTimer : Timer
     public override TimeSpan? GetTime(LiveSplitState state, TimingMethod method)
     {
         TimeSpan? lastSplit = TimeSpan.Zero;
-        var runEndedDelay = state.CurrentPhase == TimerPhase.Ended ? 1 : 0;
+        int runEndedDelay = state.CurrentPhase == TimerPhase.Ended ? 1 : 0;
         if (state.CurrentSplitIndex > 0 + runEndedDelay)
         {
             if (state.Run[state.CurrentSplitIndex - 1 - runEndedDelay].SplitTime[method] != null)

--- a/src/LiveSplit.DetailedTimer/UI/Components/SegmentTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/SegmentTimer.cs
@@ -13,13 +13,22 @@ public class SegmentTimer : Timer
         if (state.CurrentSplitIndex > 0 + runEndedDelay)
         {
             if (state.Run[state.CurrentSplitIndex - 1 - runEndedDelay].SplitTime[method] != null)
+            {
                 lastSplit = state.Run[state.CurrentSplitIndex - 1 - runEndedDelay].SplitTime[method].Value;
+            }
             else
+            {
                 lastSplit = null;
+            }
         }
+
         if (state.CurrentPhase == TimerPhase.NotRunning)
+        {
             return state.Run.Offset;
+        }
         else
+        {
             return state.CurrentTime[method] - lastSplit;
+        }
     }
 }

--- a/src/LiveSplit.DetailedTimer/UI/Components/SegmentTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/SegmentTimer.cs
@@ -1,25 +1,25 @@
-﻿using LiveSplit.Model;
-using System;
+﻿using System;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+
+namespace LiveSplit.UI.Components;
+
+public class SegmentTimer : Timer
 {
-    public class SegmentTimer : Timer
+    public override TimeSpan? GetTime(LiveSplitState state, TimingMethod method)
     {
-        public override TimeSpan? GetTime(LiveSplitState state, TimingMethod method)
+        TimeSpan? lastSplit = TimeSpan.Zero;
+        var runEndedDelay = state.CurrentPhase == TimerPhase.Ended ? 1 : 0;
+        if (state.CurrentSplitIndex > 0 + runEndedDelay)
         {
-            TimeSpan? lastSplit = TimeSpan.Zero;
-            var runEndedDelay = state.CurrentPhase == TimerPhase.Ended ? 1 : 0;
-            if (state.CurrentSplitIndex > 0 + runEndedDelay)
-            {
-                if (state.Run[state.CurrentSplitIndex - 1 - runEndedDelay].SplitTime[method] != null)
-                    lastSplit = state.Run[state.CurrentSplitIndex - 1 - runEndedDelay].SplitTime[method].Value;
-                else
-                    lastSplit = null;
-            }
-            if (state.CurrentPhase == TimerPhase.NotRunning)
-                return state.Run.Offset;
+            if (state.Run[state.CurrentSplitIndex - 1 - runEndedDelay].SplitTime[method] != null)
+                lastSplit = state.Run[state.CurrentSplitIndex - 1 - runEndedDelay].SplitTime[method].Value;
             else
-                return state.CurrentTime[method] - lastSplit;
+                lastSplit = null;
         }
+        if (state.CurrentPhase == TimerPhase.NotRunning)
+            return state.Run.Offset;
+        else
+            return state.CurrentTime[method] - lastSplit;
     }
 }


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
