### PR TITLE
Localize DetailedTimer runtime settings labels

### DIFF
--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimerSettings.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 
+using LiveSplit.Localization;
 using LiveSplit.Model;
 using LiveSplit.Model.Comparisons;
 using LiveSplit.TimeFormatters;
@@ -12,6 +13,8 @@ namespace LiveSplit.UI.Components;
 
 public partial class DetailedTimerSettings : UserControl
 {
+    private static string T(string source) => UiLocalizer.Translate(source, LanguageResolver.ResolveCurrentCultureLanguage());
+
     public new float Height { get; set; }
     public new float Width { get; set; }
     public float SegmentTimerSizeRatio { get; set; }
@@ -441,7 +444,7 @@ public partial class DetailedTimerSettings : UserControl
             trkSize.Minimum = 50;
             trkSize.Maximum = 500;
             trkSize.DataBindings.Add("Value", this, "Width", false, DataSourceUpdateMode.OnPropertyChanged);
-            lblSize.Text = "Width:";
+            lblSize.Text = T("Width:");
         }
         else
         {
@@ -449,7 +452,7 @@ public partial class DetailedTimerSettings : UserControl
             trkSize.Minimum = 20;
             trkSize.Maximum = 150;
             trkSize.DataBindings.Add("Value", this, "Height", false, DataSourceUpdateMode.OnPropertyChanged);
-            lblSize.Text = "Height:";
+            lblSize.Text = T("Height:");
         }
     }
 


### PR DESCRIPTION
## Summary`nThis PR localizes runtime-generated DetailedTimer settings labels so they participate in the new LiveSplit UI localization flow.