### PR TITLE
Add GlobalFontConsumer attribute for per-component font override support

### DIFF
--- a/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
+++ b/src/LiveSplit.DetailedTimer/UI/Components/DetailedTimer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -14,6 +14,7 @@ using LiveSplit.TimeFormatters;
 
 namespace LiveSplit.UI.Components;
 
+[GlobalFontConsumer(GlobalFont.TimerFont)]
 public class DetailedTimer : IComponent
 {
     public Timer InternalComponent { get; set; }


### PR DESCRIPTION
## Summary
- Add `[GlobalFontConsumer]` attribute to declare which global fonts the component uses
- Enables the per-component font override system introduced in LiveSplit/LiveSplit#2688